### PR TITLE
112 add attendance feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,7 @@ marimo/_lsp/
 __marimo__/
 app.db
 *.pem
+
+
+# Generated ticket archive exports
+app/data/archives/

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -147,6 +147,12 @@ def create_app(testing=True):
             )
         }
 
+    @app.context_processor
+    def inject_csrf_token():
+        from flask_wtf.csrf import generate_csrf
+
+        return {"csrf_token": generate_csrf}
+
     from app.routes.users import user_bp
 
     app.register_blueprint(user_bp)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -96,11 +96,13 @@ def create_app(testing=True):
     # in this file, it is intentional (for registering models and events).
     from app import models  # noqa: F401
     from app.routes import queue_events  # noqa: F401
+    from app.routes.attendance import attendance_bp
     from app.routes.auth import auth_bp
     from app.routes.error import error_bp
     from app.routes.tickets import tickets_bp
     from app.routes.views import views_bp
 
+    app.register_blueprint(attendance_bp)
     app.register_blueprint(auth_bp)
     app.register_blueprint(views_bp)
     app.register_blueprint(tickets_bp)

--- a/app/attendance_utils.py
+++ b/app/attendance_utils.py
@@ -99,7 +99,12 @@ def attendance_status_for_session(session, moment: datetime | None = None) -> st
     if session.checked_out_at is not None or session.status == "checked_out":
         return "Checked out"
 
-    current_moment = ensure_aware_utc(moment or utc_now())
+    current_moment = moment if moment is not None else utc_now()
+    current_moment = (
+        current_moment.astimezone(timezone.utc)
+        if current_moment.tzinfo
+        else current_moment.replace(tzinfo=timezone.utc)
+    )
 
     last_seen = ensure_aware_utc(session.last_seen_at)
     if last_seen is None:

--- a/app/attendance_utils.py
+++ b/app/attendance_utils.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, time, timezone
 from types import SimpleNamespace
 
+from sqlalchemy.orm import joinedload
+
 from app import db
 from app.time_utils import PACIFIC_TZ, format_pacific
 
@@ -98,12 +100,12 @@ def attendance_status_for_session(session, moment: datetime | None = None) -> st
         return "Checked out"
 
     current_moment = ensure_aware_utc(moment or utc_now())
-    assert current_moment is not None
+    if current_moment is None:
+        return "Stale"
 
     last_seen = ensure_aware_utc(session.last_seen_at)
     if last_seen is None:
         last_seen = ensure_aware_utc(session.checked_in_at)
-
     if last_seen is None:
         return "Stale"
 
@@ -180,7 +182,11 @@ def build_attendance_dashboard(moment: datetime | None = None):
     local_now = moment.astimezone(PACIFIC_TZ)
 
     active_sessions = (
-        AttendanceSession.query.filter(
+        AttendanceSession.query.options(
+            joinedload(AttendanceSession.user),
+            joinedload(AttendanceSession.shift),
+        )
+        .filter(
             AttendanceSession.status == "active",
             AttendanceSession.checked_out_at.is_(None),
         )
@@ -190,7 +196,8 @@ def build_attendance_dashboard(moment: datetime | None = None):
     sessions_by_user_id = {session.user_id: session for session in active_sessions}
 
     todays_shifts = (
-        AttendanceShift.query.filter_by(
+        AttendanceShift.query.options(joinedload(AttendanceShift.user))
+        .filter_by(
             day_of_week=local_now.weekday(),
             is_active=True,
         )

--- a/app/attendance_utils.py
+++ b/app/attendance_utils.py
@@ -97,11 +97,17 @@ def attendance_status_for_session(session, moment: datetime | None = None) -> st
     if session.checked_out_at is not None or session.status == "checked_out":
         return "Checked out"
 
-    moment = ensure_aware_utc(moment or utc_now())
-    last_seen = ensure_aware_utc(session.last_seen_at) or ensure_aware_utc(
-        session.checked_in_at
-    )
-    elapsed_minutes = (moment - last_seen).total_seconds() / 60
+    current_moment = ensure_aware_utc(moment or utc_now())
+    assert current_moment is not None
+
+    last_seen = ensure_aware_utc(session.last_seen_at)
+    if last_seen is None:
+        last_seen = ensure_aware_utc(session.checked_in_at)
+
+    if last_seen is None:
+        return "Stale"
+
+    elapsed_minutes = (current_moment - last_seen).total_seconds() / 60
 
     if elapsed_minutes <= ACTIVE_MINUTES:
         return "Present"

--- a/app/attendance_utils.py
+++ b/app/attendance_utils.py
@@ -1,0 +1,252 @@
+"""Attendance helpers for check-ins, scheduled shifts, and activity tracking."""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timezone
+from types import SimpleNamespace
+
+from app import db
+from app.time_utils import PACIFIC_TZ, format_pacific
+
+ACTIVE_MINUTES = 5
+IDLE_MINUTES = 15
+SHIFT_GRACE_MINUTES = 15
+
+DAY_NAMES = [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+]
+
+
+def utc_now() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+    return datetime.now(timezone.utc)
+
+
+def ensure_aware_utc(value: datetime | None) -> datetime | None:
+    """Normalize stored datetimes that may come back from SQLite as naive UTC."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def active_attendance_session_for_user(user_id: int):
+    """Return the user's open attendance session, if one exists."""
+    from app.models import AttendanceSession
+
+    return (
+        AttendanceSession.query.filter(
+            AttendanceSession.user_id == user_id,
+            AttendanceSession.status == "active",
+            AttendanceSession.checked_out_at.is_(None),
+        )
+        .order_by(AttendanceSession.checked_in_at.desc())
+        .first()
+    )
+
+
+def _time_to_minutes(value: time) -> int:
+    return value.hour * 60 + value.minute
+
+
+def shift_matches_moment(shift, moment: datetime | None = None) -> bool:
+    """Return True when a shift is active around the current Pacific-local time."""
+    moment = moment or utc_now()
+    local_now = moment.astimezone(PACIFIC_TZ)
+    if shift.day_of_week != local_now.weekday():
+        return False
+
+    current_minutes = _time_to_minutes(local_now.time())
+    start_minutes = _time_to_minutes(shift.start_time) - SHIFT_GRACE_MINUTES
+    end_minutes = _time_to_minutes(shift.end_time) + SHIFT_GRACE_MINUTES
+    return start_minutes <= current_minutes <= end_minutes
+
+
+def current_shift_for_user(user_id: int, moment: datetime | None = None):
+    """Find the active scheduled shift for a user, allowing a small grace period."""
+    from app.models import AttendanceShift
+
+    moment = moment or utc_now()
+    local_now = moment.astimezone(PACIFIC_TZ)
+    shifts = (
+        AttendanceShift.query.filter_by(
+            user_id=user_id,
+            day_of_week=local_now.weekday(),
+            is_active=True,
+        )
+        .order_by(AttendanceShift.start_time)
+        .all()
+    )
+    for shift in shifts:
+        if shift_matches_moment(shift, moment):
+            return shift
+    return None
+
+
+def attendance_status_for_session(session, moment: datetime | None = None) -> str:
+    """Return a derived present/idle/stale/checked-out status label."""
+    if session is None:
+        return "Missing"
+    if session.checked_out_at is not None or session.status == "checked_out":
+        return "Checked out"
+
+    moment = ensure_aware_utc(moment or utc_now())
+    last_seen = ensure_aware_utc(session.last_seen_at) or ensure_aware_utc(
+        session.checked_in_at
+    )
+    elapsed_minutes = (moment - last_seen).total_seconds() / 60
+
+    if elapsed_minutes <= ACTIVE_MINUTES:
+        return "Present"
+    if elapsed_minutes <= IDLE_MINUTES:
+        return "Idle"
+    return "Stale"
+
+
+def attendance_status_slug(status: str) -> str:
+    """Normalize a status label for CSS class names."""
+    return status.lower().replace(" ", "-")
+
+
+def touch_attendance(user_id: int, commit: bool = True):
+    """Refresh the last-seen timestamp for a user's active attendance session."""
+    active_session = active_attendance_session_for_user(user_id)
+    if active_session:
+        active_session.last_seen_at = utc_now()
+        if commit:
+            db.session.commit()
+    return active_session
+
+
+def record_attendance_activity(
+    user_id: int,
+    activity_type: str,
+    description: str,
+    ticket_id: int | None = None,
+    commit: bool = True,
+):
+    """Create an attendance activity row and update last_seen for active sessions."""
+    from app.models import AttendanceActivity
+
+    active_session = active_attendance_session_for_user(user_id)
+    now = utc_now()
+
+    if active_session:
+        active_session.last_seen_at = now
+
+    activity = AttendanceActivity(
+        user_id=user_id,
+        attendance_session_id=active_session.id if active_session else None,
+        ticket_id=ticket_id,
+        activity_type=activity_type,
+        description=description,
+        created_at=now,
+    )
+    db.session.add(activity)
+
+    if commit:
+        db.session.commit()
+
+    return activity
+
+
+def format_shift_time_range(shift) -> str:
+    """Return a compact local time range for a scheduled shift."""
+    return (
+        f"{DAY_NAMES[shift.day_of_week]} "
+        f"{shift.start_time.strftime('%I:%M %p').lstrip('0')}–"
+        f"{shift.end_time.strftime('%I:%M %p').lstrip('0')}"
+    )
+
+
+def build_attendance_dashboard(moment: datetime | None = None):
+    """Build dashboard rows comparing scheduled shifts against live check-ins."""
+    from app.models import AttendanceSession, AttendanceShift
+
+    moment = moment or utc_now()
+    local_now = moment.astimezone(PACIFIC_TZ)
+
+    active_sessions = (
+        AttendanceSession.query.filter(
+            AttendanceSession.status == "active",
+            AttendanceSession.checked_out_at.is_(None),
+        )
+        .order_by(AttendanceSession.checked_in_at)
+        .all()
+    )
+    sessions_by_user_id = {session.user_id: session for session in active_sessions}
+
+    todays_shifts = (
+        AttendanceShift.query.filter_by(
+            day_of_week=local_now.weekday(),
+            is_active=True,
+        )
+        .order_by(AttendanceShift.start_time)
+        .all()
+    )
+    scheduled_now = [
+        shift for shift in todays_shifts if shift_matches_moment(shift, moment)
+    ]
+
+    rows = []
+    scheduled_user_ids = set()
+
+    for shift in scheduled_now:
+        scheduled_user_ids.add(shift.user_id)
+        session = sessions_by_user_id.get(shift.user_id)
+        status = attendance_status_for_session(session, moment) if session else "Missing"
+        rows.append(
+            SimpleNamespace(
+                user=shift.user,
+                schedule=format_shift_time_range(shift),
+                location=shift.location,
+                checked_in_at=session.checked_in_at if session else None,
+                last_seen_at=session.last_seen_at if session else None,
+                status=status,
+                status_slug=attendance_status_slug(status),
+                session=session,
+                source="scheduled",
+            )
+        )
+
+    for session in active_sessions:
+        if session.user_id in scheduled_user_ids:
+            continue
+        status = attendance_status_for_session(session, moment)
+        rows.append(
+            SimpleNamespace(
+                user=session.user,
+                schedule="Unscheduled check-in",
+                location=session.shift.location if session.shift else "Wormhole",
+                checked_in_at=session.checked_in_at,
+                last_seen_at=session.last_seen_at,
+                status=status,
+                status_slug=attendance_status_slug(status),
+                session=session,
+                source="unscheduled",
+            )
+        )
+
+    summary = SimpleNamespace(
+        present=sum(1 for row in rows if row.status == "Present"),
+        idle=sum(1 for row in rows if row.status == "Idle"),
+        stale=sum(1 for row in rows if row.status == "Stale"),
+        missing=sum(1 for row in rows if row.status == "Missing"),
+        total=len(rows),
+    )
+
+    return rows, summary
+
+
+def format_datetime_for_display(value: datetime | None, fmt: str = "%I:%M %p") -> str:
+    """Format a UTC datetime in Pacific time for templates or JSON responses."""
+    if value is None:
+        return "—"
+    return format_pacific(ensure_aware_utc(value), fmt)

--- a/app/attendance_utils.py
+++ b/app/attendance_utils.py
@@ -100,8 +100,6 @@ def attendance_status_for_session(session, moment: datetime | None = None) -> st
         return "Checked out"
 
     current_moment = ensure_aware_utc(moment or utc_now())
-    if current_moment is None:
-        return "Stale"
 
     last_seen = ensure_aware_utc(session.last_seen_at)
     if last_seen is None:

--- a/app/attendance_utils.py
+++ b/app/attendance_utils.py
@@ -201,7 +201,9 @@ def build_attendance_dashboard(moment: datetime | None = None):
     for shift in scheduled_now:
         scheduled_user_ids.add(shift.user_id)
         session = sessions_by_user_id.get(shift.user_id)
-        status = attendance_status_for_session(session, moment) if session else "Missing"
+        status = (
+            attendance_status_for_session(session, moment) if session else "Missing"
+        )
         rows.append(
             SimpleNamespace(
                 user=shift.user,

--- a/app/data/archives/wormhole_archive_2026-04-22_to_2026-04-23.csv
+++ b/app/data/archives/wormhole_archive_2026-04-22_to_2026-04-23.csv
@@ -1,0 +1,2 @@
+Ticket ID,Student Name,Table,Course,Status,Created At,Closed At,Students Helped,Assistant ID,Assistant Name,Ticket Type
+1,ExportMe,T1,Ph 211,,2026-04-23 23:56:20,2026-04-22 19:00:00,1,Unassigned,N/A,Box

--- a/app/data/archives/wormhole_archive_2026-04-22_to_2026-04-23.csv
+++ b/app/data/archives/wormhole_archive_2026-04-22_to_2026-04-23.csv
@@ -1,2 +1,2 @@
 Ticket ID,Student Name,Table,Course,Status,Created At,Closed At,Students Helped,Assistant ID,Assistant Name,Ticket Type
-1,ExportMe,T1,Ph 211,,2026-04-23 23:56:20,2026-04-22 19:00:00,1,Unassigned,N/A,Box
+1,ExportMe,T1,Ph 211,,2026-04-24 00:05:19,2026-04-22 19:00:00,1,Unassigned,N/A,Box

--- a/app/data/archives/wormhole_archive_2026-04-22_to_2026-04-23.csv
+++ b/app/data/archives/wormhole_archive_2026-04-22_to_2026-04-23.csv
@@ -1,2 +1,2 @@
 Ticket ID,Student Name,Table,Course,Status,Created At,Closed At,Students Helped,Assistant ID,Assistant Name,Ticket Type
-1,ExportMe,T1,Ph 211,,2026-04-24 00:05:19,2026-04-22 19:00:00,1,Unassigned,N/A,Box
+1,ExportMe,T1,Ph 211,,2026-04-24 01:00:40,2026-04-22 19:00:00,1,Unassigned,N/A,Box

--- a/app/data/archives/wormhole_archive_2026-04-22_to_2026-04-23.csv
+++ b/app/data/archives/wormhole_archive_2026-04-22_to_2026-04-23.csv
@@ -1,2 +1,0 @@
-Ticket ID,Student Name,Table,Course,Status,Created At,Closed At,Students Helped,Assistant ID,Assistant Name,Ticket Type
-1,ExportMe,T1,Ph 211,,2026-04-24 01:00:40,2026-04-22 19:00:00,1,Unassigned,N/A,Box

--- a/app/forms.py
+++ b/app/forms.py
@@ -168,6 +168,9 @@ class AttendanceShiftDeleteForm(FlaskForm):
 class AttendanceShiftForm(FlaskForm):
     """Admin form for creating recurring scheduled Wormhole shifts."""
 
+    # Choices are still limited to non-admin active assistants in the UI, but
+    # validate_choice=False lets the route perform the authoritative server-side
+    # lookup/rejection for crafted POSTs that submit an admin or unknown user ID.
     user_id = SelectField(
         "Assistant",
         coerce=int,

--- a/app/forms.py
+++ b/app/forms.py
@@ -11,8 +11,9 @@ from wtforms import (
     SelectField,
     StringField,
     SubmitField,
+    TimeField,
 )
-from wtforms.validators import DataRequired, Email, EqualTo, NumberRange, Optional
+from wtforms.validators import DataRequired, Email, EqualTo, InputRequired, NumberRange, Optional
 
 
 def _subtract_months(from_date: date, months: int) -> date:
@@ -137,6 +138,44 @@ class ResolveTicketForm(FlaskForm):
         validators=[DataRequired(message="Please select a reason.")],
     )
     submit = SubmitField("Submit")
+
+
+
+
+class AttendanceCheckInForm(FlaskForm):
+    """CSRF-protected form for assistant attendance check-in."""
+
+    submit = SubmitField("Check In")
+
+
+class AttendanceCheckOutForm(FlaskForm):
+    """CSRF-protected form for assistant attendance check-out."""
+
+    submit = SubmitField("Check Out")
+
+
+class AttendanceShiftForm(FlaskForm):
+    """Admin form for creating recurring scheduled Wormhole shifts."""
+
+    user_id = SelectField("Assistant", coerce=int, validators=[InputRequired()])
+    day_of_week = SelectField(
+        "Day",
+        coerce=int,
+        choices=[
+            (0, "Monday"),
+            (1, "Tuesday"),
+            (2, "Wednesday"),
+            (3, "Thursday"),
+            (4, "Friday"),
+            (5, "Saturday"),
+            (6, "Sunday"),
+        ],
+        validators=[InputRequired()],
+    )
+    start_time = TimeField("Start Time", validators=[DataRequired()])
+    end_time = TimeField("End Time", validators=[DataRequired()])
+    location = StringField("Location", default="Wormhole", validators=[Optional()])
+    submit = SubmitField("Add Shift")
 
 
 class ExportArchiveForm(FlaskForm):

--- a/app/forms.py
+++ b/app/forms.py
@@ -169,11 +169,11 @@ class AttendanceShiftForm(FlaskForm):
     """Admin form for creating recurring scheduled Wormhole shifts."""
 
     user_id = SelectField(
-    "Assistant",
-    coerce=int,
-    validators=[DataRequired()],
-    validate_choice=False,
-)
+        "Assistant",
+        coerce=int,
+        validators=[DataRequired()],
+        validate_choice=False,
+    )
     day_of_week = SelectField(
         "Day",
         coerce=int,

--- a/app/forms.py
+++ b/app/forms.py
@@ -159,10 +159,21 @@ class AttendanceCheckOutForm(FlaskForm):
     submit = SubmitField("Check Out")
 
 
+class AttendanceShiftDeleteForm(FlaskForm):
+    """CSRF-protected form for removing recurring attendance shifts."""
+
+    submit = SubmitField("Remove")
+
+
 class AttendanceShiftForm(FlaskForm):
     """Admin form for creating recurring scheduled Wormhole shifts."""
 
-    user_id = SelectField("Assistant", coerce=int, validators=[InputRequired()])
+    user_id = SelectField(
+    "Assistant",
+    coerce=int,
+    validators=[DataRequired()],
+    validate_choice=False,
+)
     day_of_week = SelectField(
         "Day",
         coerce=int,

--- a/app/forms.py
+++ b/app/forms.py
@@ -13,7 +13,14 @@ from wtforms import (
     SubmitField,
     TimeField,
 )
-from wtforms.validators import DataRequired, Email, EqualTo, InputRequired, NumberRange, Optional
+from wtforms.validators import (
+    DataRequired,
+    Email,
+    EqualTo,
+    InputRequired,
+    NumberRange,
+    Optional,
+)
 
 
 def _subtract_months(from_date: date, months: int) -> date:
@@ -138,8 +145,6 @@ class ResolveTicketForm(FlaskForm):
         validators=[DataRequired(message="Please select a reason.")],
     )
     submit = SubmitField("Submit")
-
-
 
 
 class AttendanceCheckInForm(FlaskForm):

--- a/app/models.py
+++ b/app/models.py
@@ -187,6 +187,7 @@ class Skipped(Base):
     def __repr__(self) -> str:
         return f"<User {self.wa_id} skipped Ticket {self.tkt_id}>"
 
+
 class AttendanceShift(Base):
     """Recurring scheduled Wormhole shift for a user.
 
@@ -296,4 +297,3 @@ class AttendanceActivity(Base):
             f"<AttendanceActivity(id={self.id}, user_id={self.user_id}, "
             f"type={self.activity_type})>"
         )
-

--- a/app/models.py
+++ b/app/models.py
@@ -10,7 +10,7 @@ Typical usage example:
     from app import models
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, time, timezone
 from typing import Optional
 
 import sqlalchemy as sa
@@ -68,6 +68,19 @@ class User(Base):
 
     skipped: orm.Mapped["Skipped"] = orm.relationship(back_populates="user")
 
+    attendance_shifts: orm.Mapped[list["AttendanceShift"]] = orm.relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    attendance_sessions: orm.Mapped[list["AttendanceSession"]] = orm.relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    attendance_activities: orm.Mapped[list["AttendanceActivity"]] = orm.relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+
     # Functions
     def __repr__(self) -> str:
         return f"<User(id={self.id}, username={self.username}, email={self.email})>"
@@ -114,6 +127,10 @@ class Ticket(Base):
     )
 
     skipped: Mapped[Optional["Skipped"]] = orm.relationship(back_populates="ticket")
+
+    attendance_activities: orm.Mapped[list["AttendanceActivity"]] = orm.relationship(
+        back_populates="ticket"
+    )
 
     # Functions
     def __repr__(self) -> str:
@@ -169,3 +186,114 @@ class Skipped(Base):
 
     def __repr__(self) -> str:
         return f"<User {self.wa_id} skipped Ticket {self.tkt_id}>"
+
+class AttendanceShift(Base):
+    """Recurring scheduled Wormhole shift for a user.
+
+    day_of_week follows Python's convention: Monday=0, Sunday=6.
+    """
+
+    __tablename__ = "attendance_shifts"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        sa.ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    day_of_week: Mapped[int] = mapped_column(sa.Integer, index=True, nullable=False)
+    start_time: Mapped[time] = mapped_column(sa.Time, nullable=False)
+    end_time: Mapped[time] = mapped_column(sa.Time, nullable=False)
+    location: Mapped[str] = mapped_column(sa.String(100), default="Wormhole")
+    is_active: Mapped[bool] = mapped_column(sa.Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        index=True, default=lambda: datetime.now(timezone.utc)
+    )
+
+    user: Mapped["User"] = orm.relationship(back_populates="attendance_shifts")
+    attendance_sessions: orm.Mapped[list["AttendanceSession"]] = orm.relationship(
+        back_populates="shift"
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<AttendanceShift(id={self.id}, user_id={self.user_id}, "
+            f"day={self.day_of_week}, start={self.start_time}, end={self.end_time})>"
+        )
+
+
+class AttendanceSession(Base):
+    """A check-in/check-out attendance session for a Wormhole assistant."""
+
+    __tablename__ = "attendance_sessions"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        sa.ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    shift_id: Mapped[Optional[int]] = mapped_column(
+        sa.ForeignKey("attendance_shifts.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    checked_in_at: Mapped[datetime] = mapped_column(
+        index=True, default=lambda: datetime.now(timezone.utc)
+    )
+    last_seen_at: Mapped[datetime] = mapped_column(
+        index=True, default=lambda: datetime.now(timezone.utc)
+    )
+    checked_out_at: Mapped[Optional[datetime]] = mapped_column(default=None)
+    status: Mapped[str] = mapped_column(sa.String(20), default="active", index=True)
+    check_in_source: Mapped[str] = mapped_column(sa.String(50), default="manual")
+    notes: Mapped[Optional[str]] = mapped_column(sa.String(255), default=None)
+
+    user: Mapped["User"] = orm.relationship(back_populates="attendance_sessions")
+    shift: Mapped[Optional["AttendanceShift"]] = orm.relationship(
+        back_populates="attendance_sessions"
+    )
+    activities: orm.Mapped[list["AttendanceActivity"]] = orm.relationship(
+        back_populates="attendance_session"
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<AttendanceSession(id={self.id}, user_id={self.user_id}, "
+            f"status={self.status})>"
+        )
+
+
+class AttendanceActivity(Base):
+    """Audit-style activity event associated with assistant attendance."""
+
+    __tablename__ = "attendance_activities"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        sa.ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    attendance_session_id: Mapped[Optional[int]] = mapped_column(
+        sa.ForeignKey("attendance_sessions.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    ticket_id: Mapped[Optional[int]] = mapped_column(
+        sa.ForeignKey("tickets.id", ondelete="SET NULL"), index=True, nullable=True
+    )
+    activity_type: Mapped[str] = mapped_column(sa.String(50), index=True)
+    description: Mapped[str] = mapped_column(sa.String(255))
+    created_at: Mapped[datetime] = mapped_column(
+        index=True, default=lambda: datetime.now(timezone.utc)
+    )
+
+    user: Mapped["User"] = orm.relationship(back_populates="attendance_activities")
+    attendance_session: Mapped[Optional["AttendanceSession"]] = orm.relationship(
+        back_populates="activities"
+    )
+    ticket: Mapped[Optional["Ticket"]] = orm.relationship(
+        back_populates="attendance_activities"
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<AttendanceActivity(id={self.id}, user_id={self.user_id}, "
+            f"type={self.activity_type})>"
+        )
+

--- a/app/routes/attendance.py
+++ b/app/routes/attendance.py
@@ -69,7 +69,11 @@ def _validate_csrf_from_request() -> bool:
     if not current_app.config.get("WTF_CSRF_ENABLED", True):
         return True
 
-    token = request.headers.get("X-CSRFToken") or request.form.get("csrf_token")
+    token = (
+        request.headers.get("X-CSRFToken")
+        or request.headers.get("X-CSRF-Token")
+        or request.form.get("csrf_token")
+    )
     if not token:
         return False
 

--- a/app/routes/attendance.py
+++ b/app/routes/attendance.py
@@ -2,7 +2,16 @@
 
 from datetime import datetime, timezone
 
-from flask import Blueprint, flash, jsonify, redirect, render_template, request, session, url_for
+from flask import (
+    Blueprint,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 
 from app import db
 from app.attendance_utils import (
@@ -36,9 +45,7 @@ def _populate_shift_form_choices(form: AttendanceShiftForm) -> None:
         .all()
     )
     form.user_id.choices = [
-        (user.id, user.name or user.username)
-        for user in users
-        if not user.is_admin
+        (user.id, user.name or user.username) for user in users if not user.is_admin
     ]
 
 
@@ -113,7 +120,9 @@ def check_in():
     db.session.add(attendance_session)
     db.session.flush()
 
-    shift_text = format_shift_time_range(shift) if shift else "no matching scheduled shift"
+    shift_text = (
+        format_shift_time_range(shift) if shift else "no matching scheduled shift"
+    )
     record_attendance_activity(
         user.id,
         "check_in",

--- a/app/routes/attendance.py
+++ b/app/routes/attendance.py
@@ -1,0 +1,236 @@
+"""Routes for Wormhole assistant attendance tracking."""
+
+from datetime import datetime, timezone
+
+from flask import Blueprint, flash, jsonify, redirect, render_template, request, session, url_for
+
+from app import db
+from app.attendance_utils import (
+    DAY_NAMES,
+    active_attendance_session_for_user,
+    attendance_status_for_session,
+    build_attendance_dashboard,
+    current_shift_for_user,
+    format_datetime_for_display,
+    format_shift_time_range,
+    record_attendance_activity,
+    touch_attendance,
+    utc_now,
+)
+from app.auth_utils import admin_required, login_required
+from app.forms import AttendanceCheckInForm, AttendanceCheckOutForm, AttendanceShiftForm
+from app.models import AttendanceActivity, AttendanceSession, AttendanceShift, User
+
+attendance_bp = Blueprint("attendance", __name__, url_prefix="/attendance")
+
+
+def _current_user():
+    user_id = session.get("user_id")
+    return db.session.get(User, user_id) if user_id else None
+
+
+def _populate_shift_form_choices(form: AttendanceShiftForm) -> None:
+    users = (
+        User.query.filter_by(is_active=True)
+        .order_by(User.name.is_(None), User.name, User.username)
+        .all()
+    )
+    form.user_id.choices = [
+        (user.id, user.name or user.username)
+        for user in users
+        if not user.is_admin
+    ]
+
+
+def _redirect_back(default_endpoint: str = "views.hardware_list"):
+    target = request.form.get("next") or request.referrer
+    if target and target.startswith("/") and not target.startswith("//"):
+        return redirect(target)
+    if target and target.startswith(request.host_url):
+        return redirect(target)
+    return redirect(url_for(default_endpoint))
+
+
+@attendance_bp.route("/", methods=["GET"])
+@admin_required
+def dashboard():
+    shift_form = AttendanceShiftForm()
+    _populate_shift_form_choices(shift_form)
+
+    rows, summary = build_attendance_dashboard()
+    shifts = (
+        AttendanceShift.query.filter_by(is_active=True)
+        .join(User)
+        .order_by(AttendanceShift.day_of_week, AttendanceShift.start_time, User.name)
+        .all()
+    )
+    recent_activities = (
+        AttendanceActivity.query.order_by(AttendanceActivity.created_at.desc())
+        .limit(30)
+        .all()
+    )
+
+    return render_template(
+        "attendance.html",
+        rows=rows,
+        summary=summary,
+        shifts=shifts,
+        recent_activities=recent_activities,
+        shift_form=shift_form,
+        day_names=DAY_NAMES,
+        format_shift_time_range=format_shift_time_range,
+    )
+
+
+@attendance_bp.route("/check-in", methods=["POST"])
+@login_required
+def check_in():
+    form = AttendanceCheckInForm()
+    if not form.validate_on_submit():
+        flash("Invalid attendance request or session expired.", "error")
+        return _redirect_back()
+
+    user = _current_user()
+    if not user:
+        return jsonify({"error": "Authentication required"}), 401
+
+    existing = active_attendance_session_for_user(user.id)
+    if existing:
+        flash("You are already checked in to the Wormhole.", "info")
+        return _redirect_back()
+
+    now = utc_now()
+    shift = current_shift_for_user(user.id, now)
+    attendance_session = AttendanceSession(
+        user_id=user.id,
+        shift_id=shift.id if shift else None,
+        checked_in_at=now,
+        last_seen_at=now,
+        status="active",
+        check_in_source="manual",
+        notes=None if shift else "Checked in outside a scheduled shift.",
+    )
+    db.session.add(attendance_session)
+    db.session.flush()
+
+    shift_text = format_shift_time_range(shift) if shift else "no matching scheduled shift"
+    record_attendance_activity(
+        user.id,
+        "check_in",
+        f"Checked in for {shift_text}.",
+        commit=False,
+    )
+    db.session.commit()
+
+    flash("You are now checked in to the Wormhole.", "success")
+    return _redirect_back()
+
+
+@attendance_bp.route("/check-out", methods=["POST"])
+@login_required
+def check_out():
+    form = AttendanceCheckOutForm()
+    if not form.validate_on_submit():
+        flash("Invalid attendance request or session expired.", "error")
+        return _redirect_back()
+
+    user = _current_user()
+    if not user:
+        return jsonify({"error": "Authentication required"}), 401
+
+    attendance_session = active_attendance_session_for_user(user.id)
+    if not attendance_session:
+        flash("You are not currently checked in.", "info")
+        return _redirect_back()
+
+    record_attendance_activity(
+        user.id,
+        "check_out",
+        "Checked out of the Wormhole.",
+        commit=False,
+    )
+
+    now = datetime.now(timezone.utc)
+    attendance_session.checked_out_at = now
+    attendance_session.last_seen_at = now
+    attendance_session.status = "checked_out"
+    db.session.commit()
+
+    flash("You have checked out of the Wormhole.", "success")
+    return _redirect_back()
+
+
+@attendance_bp.route("/heartbeat", methods=["POST"])
+@login_required
+def heartbeat():
+    user = _current_user()
+    if not user:
+        return jsonify({"error": "Authentication required"}), 401
+
+    attendance_session = touch_attendance(user.id)
+    if not attendance_session:
+        return jsonify({"ok": True, "checked_in": False}), 200
+
+    return (
+        jsonify(
+            {
+                "ok": True,
+                "checked_in": True,
+                "status": attendance_status_for_session(attendance_session),
+                "last_seen_at": format_datetime_for_display(
+                    attendance_session.last_seen_at,
+                    "%Y-%m-%d %H:%M:%S %Z",
+                ),
+            }
+        ),
+        200,
+    )
+
+
+@attendance_bp.route("/shifts/add", methods=["POST"])
+@admin_required
+def add_shift():
+    form = AttendanceShiftForm()
+    _populate_shift_form_choices(form)
+
+    if not form.validate_on_submit():
+        flash("Could not add shift. Please check all required fields.", "error")
+        return redirect(url_for("attendance.dashboard"))
+
+    if form.end_time.data <= form.start_time.data:
+        flash("Shift end time must be after the start time.", "error")
+        return redirect(url_for("attendance.dashboard"))
+
+    user = db.session.get(User, form.user_id.data)
+    if not user or not user.is_active:
+        flash("Selected assistant could not be found.", "error")
+        return redirect(url_for("attendance.dashboard"))
+
+    shift = AttendanceShift(
+        user_id=user.id,
+        day_of_week=form.day_of_week.data,
+        start_time=form.start_time.data,
+        end_time=form.end_time.data,
+        location=(form.location.data or "Wormhole").strip() or "Wormhole",
+        is_active=True,
+    )
+    db.session.add(shift)
+    db.session.commit()
+
+    flash("Attendance shift added.", "success")
+    return redirect(url_for("attendance.dashboard"))
+
+
+@attendance_bp.route("/shifts/<int:shift_id>/delete", methods=["POST"])
+@admin_required
+def delete_shift(shift_id):
+    shift = db.session.get(AttendanceShift, shift_id)
+    if not shift:
+        flash("Shift not found.", "error")
+        return redirect(url_for("attendance.dashboard"))
+
+    shift.is_active = False
+    db.session.commit()
+
+    flash("Attendance shift removed.", "success")
+    return redirect(url_for("attendance.dashboard"))

--- a/app/routes/attendance.py
+++ b/app/routes/attendance.py
@@ -1,9 +1,8 @@
 """Routes for Wormhole assistant attendance tracking."""
 
-from datetime import datetime, timezone
-
 from flask import (
     Blueprint,
+    current_app,
     flash,
     jsonify,
     redirect,
@@ -12,6 +11,8 @@ from flask import (
     session,
     url_for,
 )
+from flask_wtf.csrf import validate_csrf
+from sqlalchemy.orm import joinedload
 
 from app import db
 from app.attendance_utils import (
@@ -27,7 +28,12 @@ from app.attendance_utils import (
     utc_now,
 )
 from app.auth_utils import admin_required, login_required
-from app.forms import AttendanceCheckInForm, AttendanceCheckOutForm, AttendanceShiftForm
+from app.forms import (
+    AttendanceCheckInForm,
+    AttendanceCheckOutForm,
+    AttendanceShiftDeleteForm,
+    AttendanceShiftForm,
+)
 from app.models import AttendanceActivity, AttendanceSession, AttendanceShift, User
 
 attendance_bp = Blueprint("attendance", __name__, url_prefix="/attendance")
@@ -58,21 +64,40 @@ def _redirect_back(default_endpoint: str = "views.hardware_list"):
     return redirect(url_for(default_endpoint))
 
 
+def _validate_csrf_from_request() -> bool:
+    """Validate CSRF for AJAX endpoints that cannot use hidden FlaskForm fields."""
+    if not current_app.config.get("WTF_CSRF_ENABLED", True):
+        return True
+
+    token = request.headers.get("X-CSRFToken") or request.form.get("csrf_token")
+    if not token:
+        return False
+
+    try:
+        validate_csrf(token)
+    except Exception:
+        return False
+    return True
+
+
 @attendance_bp.route("/", methods=["GET"])
 @admin_required
 def dashboard():
     shift_form = AttendanceShiftForm()
+    delete_shift_form = AttendanceShiftDeleteForm()
     _populate_shift_form_choices(shift_form)
 
     rows, summary = build_attendance_dashboard()
     shifts = (
         AttendanceShift.query.filter_by(is_active=True)
+        .options(joinedload(AttendanceShift.user))
         .join(User)
         .order_by(AttendanceShift.day_of_week, AttendanceShift.start_time, User.name)
         .all()
     )
     recent_activities = (
-        AttendanceActivity.query.order_by(AttendanceActivity.created_at.desc())
+        AttendanceActivity.query.options(joinedload(AttendanceActivity.user))
+        .order_by(AttendanceActivity.created_at.desc())
         .limit(30)
         .all()
     )
@@ -84,6 +109,7 @@ def dashboard():
         shifts=shifts,
         recent_activities=recent_activities,
         shift_form=shift_form,
+        delete_shift_form=delete_shift_form,
         day_names=DAY_NAMES,
         format_shift_time_range=format_shift_time_range,
     )
@@ -159,7 +185,7 @@ def check_out():
         commit=False,
     )
 
-    now = datetime.now(timezone.utc)
+    now = utc_now()
     attendance_session.checked_out_at = now
     attendance_session.last_seen_at = now
     attendance_session.status = "checked_out"
@@ -172,6 +198,9 @@ def check_out():
 @attendance_bp.route("/heartbeat", methods=["POST"])
 @login_required
 def heartbeat():
+    if not _validate_csrf_from_request():
+        return jsonify({"error": "Invalid or missing CSRF token"}), 400
+
     user = _current_user()
     if not user:
         return jsonify({"error": "Authentication required"}), 401
@@ -214,6 +243,9 @@ def add_shift():
     if not user or not user.is_active:
         flash("Selected assistant could not be found.", "error")
         return redirect(url_for("attendance.dashboard"))
+    if user.is_admin:
+        flash("Admin users cannot be assigned attendance shifts.", "error")
+        return redirect(url_for("attendance.dashboard"))
 
     shift = AttendanceShift(
         user_id=user.id,
@@ -233,6 +265,11 @@ def add_shift():
 @attendance_bp.route("/shifts/<int:shift_id>/delete", methods=["POST"])
 @admin_required
 def delete_shift(shift_id):
+    form = AttendanceShiftDeleteForm()
+    if not form.validate_on_submit():
+        flash("Invalid attendance request or session expired.", "error")
+        return redirect(url_for("attendance.dashboard"))
+
     shift = db.session.get(AttendanceShift, shift_id)
     if not shift:
         flash("Shift not found.", "error")

--- a/app/routes/tickets.py
+++ b/app/routes/tickets.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from flask import Blueprint, flash, jsonify, redirect, request, session, url_for
 
 from app import db
+from app.attendance_utils import record_attendance_activity
 from app.models import Skipped, Ticket, User
 from app.routes.queue_events import broadcast_ticket_update
 
@@ -113,6 +114,12 @@ def resolve_ticket(ticket_id):
             ticket.closed_at = datetime.now(timezone.utc)
             ticket.number_of_students = 0
             db.session.commit()
+            record_attendance_activity(
+                user.id,
+                "ticket_resolved",
+                f"Resolved ticket #{ticket.id} as duplicate.",
+                ticket_id=ticket.id,
+            )
             broadcast_ticket_update(ticket.id)
             flash("Ticket marked as duplicate and resolved successfully", "success")
             return redirect(url_for("views.userpage", username=user.username))
@@ -127,6 +134,12 @@ def resolve_ticket(ticket_id):
             ticket.closed_at = datetime.now(timezone.utc)
             ticket.number_of_students = number_students
             db.session.commit()
+            record_attendance_activity(
+                user.id,
+                "ticket_resolved",
+                f"Resolved ticket #{ticket.id} as helped.",
+                ticket_id=ticket.id,
+            )
             broadcast_ticket_update(ticket.id)
             flash(
                 f"Ticket marked as helped and resolved successfully ({number_students} students)",
@@ -144,6 +157,12 @@ def resolve_ticket(ticket_id):
             ticket.closed_at = datetime.now(timezone.utc)
             ticket.number_of_students = 0
             db.session.commit()
+            record_attendance_activity(
+                user.id,
+                "ticket_resolved",
+                f"Resolved ticket #{ticket.id} as no show.",
+                ticket_id=ticket.id,
+            )
             broadcast_ticket_update(ticket.id)
             flash("Ticket marked as no show and resolved successfully", "success")
             return redirect(url_for("views.userpage", username=user.username))
@@ -157,6 +176,12 @@ def resolve_ticket(ticket_id):
             ticket.wa_id = None
             ticket.wormhole_assistant = None
             db.session.commit()
+            record_attendance_activity(
+                user.id,
+                "ticket_returned",
+                f"Returned ticket #{ticket.id} to the queue.",
+                ticket_id=ticket.id,
+            )
             broadcast_ticket_update(ticket.id)
 
             skipped = Skipped(wa_id=user.id, tkt_id=ticket_id)

--- a/app/routes/views.py
+++ b/app/routes/views.py
@@ -22,8 +22,17 @@ from flask import (
 from sqlalchemy import and_, func, or_, text
 
 from app import db
+from app.attendance_utils import (
+    active_attendance_session_for_user,
+    attendance_status_for_session,
+    build_attendance_dashboard,
+    record_attendance_activity,
+    touch_attendance,
+)
 from app.auth_utils import admin_required, login_required
 from app.forms import (
+    AttendanceCheckInForm,
+    AttendanceCheckOutForm,
     ChangePassForm,
     ClearQueueForm,
     DeleteArchiveForm,
@@ -37,7 +46,7 @@ from app.forms import (
     ResolveTicketForm,
     TicketForm,
 )
-from app.models import Skipped, Ticket, User
+from app.models import AttendanceActivity, Skipped, Ticket, User
 from app.time_utils import (
     PACIFIC_TZ,
     format_pacific,
@@ -168,6 +177,19 @@ def queue():
     cul = [_ticket_to_ns(t) for t in current_tickets]
     cll = [_ticket_to_ns(t) for t in closed_tickets]
 
+    touch_attendance(current_user_obj.id)
+
+    attendance_rows = []
+    attendance_summary = None
+    recent_attendance_activities = []
+    if current_user_obj.is_admin:
+        attendance_rows, attendance_summary = build_attendance_dashboard()
+        recent_attendance_activities = (
+            AttendanceActivity.query.order_by(AttendanceActivity.created_at.desc())
+            .limit(10)
+            .all()
+        )
+
     # Use dedicated CSRF-protected forms for admin queue actions
     flush_form = FlushQueueForm()
     clear_form = ClearQueueForm()
@@ -181,6 +203,9 @@ def queue():
         user=current_user_obj,
         flush_form=flush_form,
         clear_form=clear_form,
+        attendance_rows=attendance_rows,
+        attendance_summary=attendance_summary,
+        recent_attendance_activities=recent_attendance_activities,
     )
 
 
@@ -348,7 +373,27 @@ def dashboard():
 def hardware_list():
     # Placeholder for hardware list - will be populated with actual data
     boxes = []
-    return render_template("hardware_list.html", boxes=boxes)
+    sid = session.get("user_id")
+    current_user_obj = db.session.get(User, sid) if sid else None
+    active_session = (
+        active_attendance_session_for_user(current_user_obj.id)
+        if current_user_obj
+        else None
+    )
+    attendance_status = (
+        attendance_status_for_session(active_session) if active_session else None
+    )
+    check_in_form = AttendanceCheckInForm()
+    check_out_form = AttendanceCheckOutForm()
+    touch_attendance(current_user_obj.id) if current_user_obj else None
+    return render_template(
+        "hardware_list.html",
+        boxes=boxes,
+        attendance_session=active_session,
+        attendance_status=attendance_status,
+        check_in_form=check_in_form,
+        check_out_form=check_out_form,
+    )
 
 
 @views_bp.route("/logout")
@@ -552,6 +597,7 @@ def download_archive(filename):
 
 
 @views_bp.route("/user/<username>")
+@login_required
 def userpage(username):
     u = User.query.filter_by(username=username).first()
     if not u:
@@ -575,19 +621,37 @@ def userpage(username):
     )
     skipped_all = ticket_count == 0
     # create minimal surface for template
+    active_session = active_attendance_session_for_user(u.id)
+    attendance_status = (
+        attendance_status_for_session(active_session) if active_session else None
+    )
+    if session.get("user_id") == u.id:
+        touch_attendance(u.id)
+
     user_ns = SimpleNamespace(
+        id=u.id,
         username=u.username,
         email=u.email,
+        name=u.name,
         is_admin=u.is_admin,
         tkt=current_ticket,
         all_tkt_assoc_sorted=lambda: [],
     )
-    current_user = user_ns
+    logged_in_user = db.session.get(User, session.get("user_id"))
+    current_user = SimpleNamespace(
+        username=logged_in_user.username if logged_in_user else "",
+        is_admin=bool(logged_in_user.is_admin) if logged_in_user else False,
+        is_anonymous=logged_in_user is None,
+    )
     return render_template(
         "userpage.html",
         user=user_ns,
         current_user=current_user,
         skipped_all=skipped_all,
+        attendance_session=active_session,
+        attendance_status=attendance_status,
+        check_in_form=AttendanceCheckInForm(),
+        check_out_form=AttendanceCheckOutForm(),
     )
 
 
@@ -620,6 +684,12 @@ def getnewticket(username):
         return redirect(url_for("views.userpage", username=username))
 
     t.assign_to(u)
+    record_attendance_activity(
+        u.id,
+        "ticket_claimed",
+        f"Claimed ticket #{t.id} for {t.student_name}.",
+        ticket_id=t.id,
+    )
 
     try:
         from app.routes.queue_events import broadcast_ticket_update
@@ -829,6 +899,12 @@ def pastticket(username, tktid):
         t.wa_id = current_user_obj.id
 
         t.close_ticket(closed_reason=form.resolveReason.data, num_students=num_stds)
+        record_attendance_activity(
+            current_user_obj.id,
+            "ticket_resolved",
+            f"Resolved ticket #{t.id} as {form.resolveReason.data}.",
+            ticket_id=t.id,
+        )
 
         flash("Ticket resolved successfully.", "success")
 

--- a/app/routes/views.py
+++ b/app/routes/views.py
@@ -630,16 +630,9 @@ def userpage(username):
         tkt=current_ticket,
         all_tkt_assoc_sorted=lambda: [],
     )
-    logged_in_user = db.session.get(User, session.get("user_id"))
-    current_user = SimpleNamespace(
-        username=logged_in_user.username if logged_in_user else "",
-        is_admin=bool(logged_in_user.is_admin) if logged_in_user else False,
-        is_anonymous=logged_in_user is None,
-    )
     return render_template(
         "userpage.html",
         user=user_ns,
-        current_user=current_user,
         skipped_all=skipped_all,
         attendance_session=active_session,
         attendance_status=attendance_status,

--- a/app/routes/views.py
+++ b/app/routes/views.py
@@ -46,7 +46,7 @@ from app.forms import (
     ResolveTicketForm,
     TicketForm,
 )
-from app.models import AttendanceActivity, Skipped, Ticket, User
+from app.models import Skipped, Ticket, User
 from app.time_utils import (
     PACIFIC_TZ,
     format_pacific,
@@ -181,14 +181,8 @@ def queue():
 
     attendance_rows = []
     attendance_summary = None
-    recent_attendance_activities = []
     if current_user_obj.is_admin:
         attendance_rows, attendance_summary = build_attendance_dashboard()
-        recent_attendance_activities = (
-            AttendanceActivity.query.order_by(AttendanceActivity.created_at.desc())
-            .limit(10)
-            .all()
-        )
 
     # Use dedicated CSRF-protected forms for admin queue actions
     flush_form = FlushQueueForm()
@@ -205,7 +199,6 @@ def queue():
         clear_form=clear_form,
         attendance_rows=attendance_rows,
         attendance_summary=attendance_summary,
-        recent_attendance_activities=recent_attendance_activities,
     )
 
 

--- a/app/static/js/attendance.js
+++ b/app/static/js/attendance.js
@@ -4,6 +4,7 @@
 (function() {
     const script = document.currentScript;
     const heartbeatUrl = script ? script.dataset.heartbeatUrl : null;
+    const csrfToken = script ? script.dataset.csrfToken : null;
 
     if (!heartbeatUrl || !window.fetch) {
         return;
@@ -14,13 +15,19 @@
             return;
         }
 
+        const headers = {
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+        };
+
+        if (csrfToken) {
+            headers['X-CSRFToken'] = csrfToken;
+        }
+
         fetch(heartbeatUrl, {
             method: 'POST',
             credentials: 'same-origin',
-            headers: {
-                'Accept': 'application/json',
-                'X-Requested-With': 'XMLHttpRequest'
-            }
+            headers: headers
         }).catch(function() {
             // Heartbeat failures should not interrupt normal page use.
         });

--- a/app/static/js/attendance.js
+++ b/app/static/js/attendance.js
@@ -10,7 +10,21 @@
         return;
     }
 
+    let heartbeatEnabled = true;
+    let intervalId = null;
+
+    function stopHeartbeat() {
+        heartbeatEnabled = false;
+        if (intervalId !== null) {
+            window.clearInterval(intervalId);
+            intervalId = null;
+        }
+    }
+
     function sendHeartbeat() {
+        if (!heartbeatEnabled) {
+            return;
+        }
         if (document.visibilityState && document.visibilityState !== 'visible') {
             return;
         }
@@ -28,13 +42,25 @@
             method: 'POST',
             credentials: 'same-origin',
             headers: headers
-        }).catch(function() {
-            // Heartbeat failures should not interrupt normal page use.
-        });
+        })
+            .then(function(response) {
+                if (!response.ok) {
+                    return null;
+                }
+                return response.json();
+            })
+            .then(function(data) {
+                if (data && data.checked_in === false) {
+                    stopHeartbeat();
+                }
+            })
+            .catch(function() {
+                // Heartbeat failures should not interrupt normal page use.
+            });
     }
 
     window.setTimeout(sendHeartbeat, 10000);
-    window.setInterval(sendHeartbeat, 60000);
+    intervalId = window.setInterval(sendHeartbeat, 60000);
 
     document.addEventListener('visibilitychange', function() {
         if (document.visibilityState === 'visible') {

--- a/app/static/js/attendance.js
+++ b/app/static/js/attendance.js
@@ -1,0 +1,37 @@
+// app/static/js/attendance.js
+// Lightweight heartbeat for assistant attendance sessions.
+
+(function() {
+    const script = document.currentScript;
+    const heartbeatUrl = script ? script.dataset.heartbeatUrl : null;
+
+    if (!heartbeatUrl || !window.fetch) {
+        return;
+    }
+
+    function sendHeartbeat() {
+        if (document.visibilityState && document.visibilityState !== 'visible') {
+            return;
+        }
+
+        fetch(heartbeatUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Accept': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest'
+            }
+        }).catch(function() {
+            // Heartbeat failures should not interrupt normal page use.
+        });
+    }
+
+    window.setTimeout(sendHeartbeat, 10000);
+    window.setInterval(sendHeartbeat, 60000);
+
+    document.addEventListener('visibilitychange', function() {
+        if (document.visibilityState === 'visible') {
+            sendHeartbeat();
+        }
+    });
+})();

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -862,15 +862,30 @@
     line-height: 1.6;
 }
 
-.btn-primary {
-    background-color: #d73f09;
-    color: #fff;
+.btn-primary,
+.btn-delete {
     border: 0;
     border-radius: 6px;
     padding: 8px 12px;
     cursor: pointer;
 }
 
-.btn-primary:hover {
+.btn-primary {
+    background-color: #d73f09;
+    color: #fff;
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
     background-color: #b33308;
+}
+
+.btn-delete {
+    background-color: #8c1d40;
+    color: #fff;
+}
+
+.btn-delete:hover,
+.btn-delete:focus {
+    background-color: #66142f;
 }

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -737,3 +737,140 @@
         align-items: flex-start;
     }
 }
+
+
+/* Attendance feature */
+.attendance-dashboard .subsection,
+.attendance-queue-panel {
+    overflow-x: auto;
+}
+
+.attendance-helper-text,
+.attendance-muted,
+.attendance-card-text {
+    line-height: 1.5;
+}
+
+.attendance-summary-grid,
+.attendance-summary-inline {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin: 12px 0 18px;
+}
+
+.attendance-summary-card,
+.attendance-summary-inline span {
+    background: #f5f5f5;
+    border: 1px solid #d7d7d7;
+    border-radius: 8px;
+    padding: 10px 14px;
+}
+
+.attendance-summary-card strong {
+    display: block;
+    font-size: 1.6rem;
+}
+
+.attendance-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+
+.attendance-table th,
+.attendance-table td {
+    border: 1px solid #d8d8d8;
+    padding: 9px;
+    text-align: left;
+    vertical-align: top;
+}
+
+.attendance-table th {
+    background: #f0f0f0;
+}
+
+.attendance-status {
+    display: inline-block;
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-weight: 700;
+    background: #ececec;
+}
+
+.attendance-status-present {
+    background: #d7f3dd;
+}
+
+.attendance-status-idle {
+    background: #fff0c2;
+}
+
+.attendance-status-stale,
+.attendance-status-missing {
+    background: #f8d4d4;
+}
+
+.attendance-status-checked-out {
+    background: #d8e7ff;
+}
+
+.attendance-shift-form {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(155px, 1fr));
+    gap: 12px;
+    align-items: end;
+}
+
+.attendance-shift-form label {
+    display: block;
+    font-weight: 700;
+    margin-bottom: 4px;
+}
+
+.attendance-shift-form select,
+.attendance-shift-form input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 7px;
+}
+
+.attendance-form-action {
+    align-self: end;
+}
+
+.attendance-card,
+.attendance-card-inline {
+    text-align: center;
+}
+
+.attendance-card-inline {
+    border: 1px solid #d8d8d8;
+    border-radius: 8px;
+    margin: 10px 0 18px;
+    padding: 12px;
+    background: #f8f8f8;
+}
+
+.attendance-action-form,
+.inline-form {
+    display: inline-block;
+    margin: 4px;
+}
+
+.attendance-activity-list {
+    line-height: 1.6;
+}
+
+.btn-primary {
+    background-color: #d73f09;
+    color: #fff;
+    border: 0;
+    border-radius: 6px;
+    padding: 8px 12px;
+    cursor: pointer;
+}
+
+.btn-primary:hover {
+    background-color: #b33308;
+}

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -495,6 +495,20 @@
     display: inline-flex;
 }
 
+.btn-delete {
+    background-color: #8c1d40;
+    color: #fff;
+    border: 0;
+    border-radius: 6px;
+    padding: 8px 12px;
+    cursor: pointer;
+}
+
+.btn-delete:hover,
+.btn-delete:focus {
+    background-color: #66142f;
+}
+
 .queue-admin-actions .btn-delete {
     padding: 5px 10px;
     min-height: 30px;
@@ -862,14 +876,6 @@
     line-height: 1.6;
 }
 
-.btn-primary,
-.btn-delete {
-    border: 0;
-    border-radius: 6px;
-    padding: 8px 12px;
-    cursor: pointer;
-}
-
 .btn-primary {
     background-color: #d73f09;
     color: #fff;
@@ -880,12 +886,3 @@
     background-color: #b33308;
 }
 
-.btn-delete {
-    background-color: #8c1d40;
-    color: #fff;
-}
-
-.btn-delete:hover,
-.btn-delete:focus {
-    background-color: #66142f;
-}

--- a/app/templates/archive.html
+++ b/app/templates/archive.html
@@ -11,7 +11,7 @@
             <h3>
                 Export Configuration
             </h3>
-            <form action="{{ url_for("views.export_archive") }}" method="post">
+            <form action="{{ url_for('views.export_archive') }}" method="post">
                 {{ form.hidden_tag() }}
                 <div style="margin-bottom: 1rem;">
                     {{ form.start_date.label() }}
@@ -35,7 +35,9 @@
             </form>
         </div>
         <div class="section generic">
-            <h2>Archive Files</h2>
+            <h2>
+                Archive Files
+            </h2>
             <p>
                 Below is a list of previously exported archive files. Click on a file name to download it.
             </p>
@@ -50,11 +52,15 @@
                             </label>
                         </li>
                     {% else %}
-                        <li>No archive files found.</li>
+                        <li>
+                            No archive files found.
+                        </li>
                     {% endfor %}
                 </ul>
                 <div style="margin-top: 1rem;">
-                    <button type="submit" class="btn-danger">Delete Selected</button>
+                    <button type="submit" class="btn-danger">
+                        Delete Selected
+                    </button>
                 </div>
             </form>
         </div>

--- a/app/templates/attendance.html
+++ b/app/templates/attendance.html
@@ -8,7 +8,6 @@
             <p class="attendance-helper-text">
                 This view compares scheduled Wormhole shifts with assistant check-ins and recent queue activity.
             </p>
-
             <div class="attendance-summary-grid">
                 <div class="attendance-summary-card">
                     <strong>{{ summary.present }}</strong>
@@ -27,27 +26,46 @@
                     <span>Missing</span>
                 </div>
             </div>
-
             <div class="subsection">
-                <h3>Current Shift Coverage</h3>
+                <h3>
+                    Current Shift Coverage
+                </h3>
                 {% if rows %}
                     <table class="attendance-table">
                         <thead>
                             <tr>
-                                <th>Assistant</th>
-                                <th>Scheduled Shift</th>
-                                <th>Location</th>
-                                <th>Checked In</th>
-                                <th>Last Active</th>
-                                <th>Status</th>
+                                <th>
+                                    Assistant
+                                </th>
+                                <th>
+                                    Scheduled Shift
+                                </th>
+                                <th>
+                                    Location
+                                </th>
+                                <th>
+                                    Checked In
+                                </th>
+                                <th>
+                                    Last Active
+                                </th>
+                                <th>
+                                    Status
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
                             {% for row in rows %}
                                 <tr>
-                                    <td>{{ row.user.name or row.user.username }}</td>
-                                    <td>{{ row.schedule }}</td>
-                                    <td>{{ row.location }}</td>
+                                    <td>
+                                        {{ row.user.name or row.user.username }}
+                                    </td>
+                                    <td>
+                                        {{ row.schedule }}
+                                    </td>
+                                    <td>
+                                        {{ row.location }}
+                                    </td>
                                     <td>
                                         {% if row.checked_in_at %}
                                             {{ row.checked_in_at|datetime_pacific("%I:%M %p") }}
@@ -72,12 +90,15 @@
                         </tbody>
                     </table>
                 {% else %}
-                    <p>No active scheduled shifts or checked-in assistants right now.</p>
+                    <p>
+                        No active scheduled shifts or checked-in assistants right now.
+                    </p>
                 {% endif %}
             </div>
-
             <div class="subsection">
-                <h3>Add Recurring Shift</h3>
+                <h3>
+                    Add Recurring Shift
+                </h3>
                 <form action="{{ url_for('attendance.add_shift') }}"
                       method="post"
                       class="attendance-shift-form">
@@ -107,25 +128,40 @@
                     </div>
                 </form>
             </div>
-
             <div class="subsection">
-                <h3>Active Recurring Schedule</h3>
+                <h3>
+                    Active Recurring Schedule
+                </h3>
                 {% if shifts %}
                     <table class="attendance-table">
                         <thead>
                             <tr>
-                                <th>Assistant</th>
-                                <th>Shift</th>
-                                <th>Location</th>
-                                <th>Action</th>
+                                <th>
+                                    Assistant
+                                </th>
+                                <th>
+                                    Shift
+                                </th>
+                                <th>
+                                    Location
+                                </th>
+                                <th>
+                                    Action
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
                             {% for shift in shifts %}
                                 <tr>
-                                    <td>{{ shift.user.name or shift.user.username }}</td>
-                                    <td>{{ format_shift_time_range(shift) }}</td>
-                                    <td>{{ shift.location }}</td>
+                                    <td>
+                                        {{ shift.user.name or shift.user.username }}
+                                    </td>
+                                    <td>
+                                        {{ format_shift_time_range(shift) }}
+                                    </td>
+                                    <td>
+                                        {{ shift.location }}
+                                    </td>
                                     <td>
                                         <form action="{{ url_for('attendance.delete_shift', shift_id=shift.id) }}"
                                               method="post"
@@ -142,12 +178,15 @@
                         </tbody>
                     </table>
                 {% else %}
-                    <p>No recurring attendance shifts have been added yet.</p>
+                    <p>
+                        No recurring attendance shifts have been added yet.
+                    </p>
                 {% endif %}
             </div>
-
             <div class="subsection">
-                <h3>Recent Queue Activity</h3>
+                <h3>
+                    Recent Queue Activity
+                </h3>
                 {% if recent_activities %}
                     <ul class="attendance-activity-list">
                         {% for activity in recent_activities %}
@@ -161,10 +200,11 @@
                         {% endfor %}
                     </ul>
                 {% else %}
-                    <p>No attendance activity has been recorded yet.</p>
+                    <p>
+                        No attendance activity has been recorded yet.
+                    </p>
                 {% endif %}
             </div>
-
             <div class="queue-back-link">
                 <a href="{{ url_for('views.queue') }}">Back to Queue</a>
             </div>

--- a/app/templates/attendance.html
+++ b/app/templates/attendance.html
@@ -1,0 +1,173 @@
+{% extends "base.html" %}
+{% block content %}
+    <div class="page">
+        <div class="section generic attendance-dashboard">
+            <h2 class="queue-dashboard-title">
+                Attendance Dashboard
+            </h2>
+            <p class="attendance-helper-text">
+                This view compares scheduled Wormhole shifts with assistant check-ins and recent queue activity.
+            </p>
+
+            <div class="attendance-summary-grid">
+                <div class="attendance-summary-card">
+                    <strong>{{ summary.present }}</strong>
+                    <span>Present</span>
+                </div>
+                <div class="attendance-summary-card">
+                    <strong>{{ summary.idle }}</strong>
+                    <span>Idle</span>
+                </div>
+                <div class="attendance-summary-card">
+                    <strong>{{ summary.stale }}</strong>
+                    <span>Stale</span>
+                </div>
+                <div class="attendance-summary-card">
+                    <strong>{{ summary.missing }}</strong>
+                    <span>Missing</span>
+                </div>
+            </div>
+
+            <div class="subsection">
+                <h3>Current Shift Coverage</h3>
+                {% if rows %}
+                    <table class="attendance-table">
+                        <thead>
+                            <tr>
+                                <th>Assistant</th>
+                                <th>Scheduled Shift</th>
+                                <th>Location</th>
+                                <th>Checked In</th>
+                                <th>Last Active</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in rows %}
+                                <tr>
+                                    <td>{{ row.user.name or row.user.username }}</td>
+                                    <td>{{ row.schedule }}</td>
+                                    <td>{{ row.location }}</td>
+                                    <td>
+                                        {% if row.checked_in_at %}
+                                            {{ row.checked_in_at|datetime_pacific("%I:%M %p") }}
+                                        {% else %}
+                                            —
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if row.last_seen_at %}
+                                            {{ row.last_seen_at|datetime_pacific("%I:%M %p") }}
+                                        {% else %}
+                                            —
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <span class="attendance-status attendance-status-{{ row.status_slug }}">
+                                            {{ row.status }}
+                                        </span>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% else %}
+                    <p>No active scheduled shifts or checked-in assistants right now.</p>
+                {% endif %}
+            </div>
+
+            <div class="subsection">
+                <h3>Add Recurring Shift</h3>
+                <form action="{{ url_for('attendance.add_shift') }}"
+                      method="post"
+                      class="attendance-shift-form">
+                    {{ shift_form.hidden_tag() }}
+                    <div>
+                        {{ shift_form.user_id.label }}
+                        {{ shift_form.user_id() }}
+                    </div>
+                    <div>
+                        {{ shift_form.day_of_week.label }}
+                        {{ shift_form.day_of_week() }}
+                    </div>
+                    <div>
+                        {{ shift_form.start_time.label }}
+                        {{ shift_form.start_time() }}
+                    </div>
+                    <div>
+                        {{ shift_form.end_time.label }}
+                        {{ shift_form.end_time() }}
+                    </div>
+                    <div>
+                        {{ shift_form.location.label }}
+                        {{ shift_form.location() }}
+                    </div>
+                    <div class="attendance-form-action">
+                        {{ shift_form.submit(class_="btn-primary") }}
+                    </div>
+                </form>
+            </div>
+
+            <div class="subsection">
+                <h3>Active Recurring Schedule</h3>
+                {% if shifts %}
+                    <table class="attendance-table">
+                        <thead>
+                            <tr>
+                                <th>Assistant</th>
+                                <th>Shift</th>
+                                <th>Location</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for shift in shifts %}
+                                <tr>
+                                    <td>{{ shift.user.name or shift.user.username }}</td>
+                                    <td>{{ format_shift_time_range(shift) }}</td>
+                                    <td>{{ shift.location }}</td>
+                                    <td>
+                                        <form action="{{ url_for('attendance.delete_shift', shift_id=shift.id) }}"
+                                              method="post"
+                                              class="inline-form">
+                                            <button type="submit"
+                                                    class="btn-delete"
+                                                    onclick="return confirm('Remove this recurring shift?');">
+                                                Remove
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% else %}
+                    <p>No recurring attendance shifts have been added yet.</p>
+                {% endif %}
+            </div>
+
+            <div class="subsection">
+                <h3>Recent Queue Activity</h3>
+                {% if recent_activities %}
+                    <ul class="attendance-activity-list">
+                        {% for activity in recent_activities %}
+                            <li>
+                                <strong>{{ activity.user.name or activity.user.username }}</strong>
+                                — {{ activity.description }}
+                                <span class="attendance-muted">
+                                    {{ activity.created_at|datetime_pacific("%b %d, %I:%M %p") }}
+                                </span>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <p>No attendance activity has been recorded yet.</p>
+                {% endif %}
+            </div>
+
+            <div class="queue-back-link">
+                <a href="{{ url_for('views.queue') }}">Back to Queue</a>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/app/templates/attendance.html
+++ b/app/templates/attendance.html
@@ -166,6 +166,7 @@
                                         <form action="{{ url_for('attendance.delete_shift', shift_id=shift.id) }}"
                                               method="post"
                                               class="inline-form">
+                                            {{ delete_shift_form.hidden_tag() }}
                                             <button type="submit"
                                                     class="btn-delete"
                                                     onclick="return confirm('Remove this recurring shift?');">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -27,29 +27,29 @@
                     Oregon State University Wormhole
                 </h1>
                 <div class="navbar">
-                    <a href="{{ url_for("views.index") }}">Home</a>
-                    <a href="{{ url_for("views.create_ticket_page") }}">Submit Request</a>
-                    <a href="{{ url_for("views.livequeue") }}">Live Queue</a>
-                    <a href="{{ url_for("views.wiki") }}">Wiki</a>
+                    <a href="{{ url_for('views.index') }}">Home</a>
+                    <a href="{{ url_for('views.create_ticket_page') }}">Submit Request</a>
+                    <a href="{{ url_for('views.livequeue') }}">Live Queue</a>
+                    <a href="{{ url_for('views.wiki') }}">Wiki</a>
                     <div class="dropdown">
                         <button class="dropbtn">
                             User
                         </button>
                         <div class="dropdown-content">
                             {% if current_user.is_anonymous %}
-                                <a href="{{ url_for("views.assistant_login") }}">Log In</a>
+                                <a href="{{ url_for('views.assistant_login') }}">Log In</a>
                             {% else %}
                                 <a href="{{ url_for('views.userpage', username=current_user.username) }}">Profile</a>
                                 {% if current_user.is_admin %}
                                     <div class = "admin-links">
-                                        <a href="{{ url_for("views.register") }}">Register New User</a>
-                                        <a href="{{ url_for("views.queue") }}">Queue</a>
-                                        <a href="{{ url_for("attendance.dashboard") }}">Attendance</a>
-                                        <a href="{{ url_for("views.archive") }}">Archive</a>
+                                        <a href="{{ url_for('views.register') }}">Register New User</a>
+                                        <a href="{{ url_for('views.queue') }}">Queue</a>
+                                        <a href="{{ url_for('attendance.dashboard') }}">Attendance</a>
+                                        <a href="{{ url_for('views.archive') }}">Archive</a>
                                     </div>
                                 {% endif %}
-                                <a href="{{ url_for("views.hardware_list") }}">Hardware List</a>
-                                <a href="{{ url_for("views.logout") }}">Log Out</a>
+                                <a href="{{ url_for('views.hardware_list') }}">Hardware List</a>
+                                <a href="{{ url_for('views.logout') }}">Log Out</a>
                             {% endif %}
                         </div>
                     </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -44,6 +44,7 @@
                                     <div class = "admin-links">
                                         <a href="{{ url_for("views.register") }}">Register New User</a>
                                         <a href="{{ url_for("views.queue") }}">Queue</a>
+                                        <a href="{{ url_for("attendance.dashboard") }}">Attendance</a>
                                         <a href="{{ url_for("views.archive") }}">Archive</a>
                                     </div>
                                 {% endif %}
@@ -73,6 +74,10 @@
         {% block content %}
         {% endblock %}
     </body>
+    {% if not current_user.is_anonymous %}
+        <script src="{{ url_for('static', filename='js/attendance.js') }}"
+                data-heartbeat-url="{{ url_for('attendance.heartbeat') }}"></script>
+    {% endif %}
     {% block body_scripts %}
     {% endblock %}
 </html>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -73,11 +73,12 @@
         {% endwith %}
         {% block content %}
         {% endblock %}
+        {% if not current_user.is_anonymous %}
+            <script src="{{ url_for('static', filename='js/attendance.js') }}"
+                    data-heartbeat-url="{{ url_for('attendance.heartbeat') }}"
+                    data-csrf-token="{{ csrf_token() }}"></script>
+        {% endif %}
+        {% block body_scripts %}
+        {% endblock %}
     </body>
-    {% if not current_user.is_anonymous %}
-        <script src="{{ url_for('static', filename='js/attendance.js') }}"
-                data-heartbeat-url="{{ url_for('attendance.heartbeat') }}"></script>
-    {% endif %}
-    {% block body_scripts %}
-    {% endblock %}
 </html>

--- a/app/templates/currentticket.html
+++ b/app/templates/currentticket.html
@@ -65,8 +65,16 @@
                 <button type="submit" name="resolve" value="return_to_queue">
                     Return To Queue
                 </button>
-                <label for="numstudents">Number of Students:</label>
-                <input type="number" id="numstudents" name="numstudents" min="0" max="100" step="1" value="1">
+                <label for="numstudents">
+                    Number of Students:
+                </label>
+                <input type="number"
+                       id="numstudents"
+                       name="numstudents"
+                       min="0"
+                       max="100"
+                       step="1"
+                       value="1">
             </form>
         </div>
     </div>

--- a/app/templates/hardware_list.html
+++ b/app/templates/hardware_list.html
@@ -2,6 +2,31 @@
 {% block content %}
     <div class="page">
         <div class="section live-queue">
+            <div class="attendance-card-inline">
+                <h3>Wormhole Attendance</h3>
+                {% if attendance_session %}
+                    <p>
+                        Checked in since {{ attendance_session.checked_in_at|datetime_pacific("%I:%M %p") }}.
+                        Status: <strong>{{ attendance_status }}</strong>.
+                    </p>
+                    <form action="{{ url_for('attendance.check_out') }}"
+                          method="post"
+                          class="attendance-action-form">
+                        {{ check_out_form.hidden_tag() }}
+                        <input type="hidden" name="next" value="{{ request.path }}">
+                        <button type="submit" class="btn-delete">Check Out</button>
+                    </form>
+                {% else %}
+                    <p>Check in when you are present and available to help students.</p>
+                    <form action="{{ url_for('attendance.check_in') }}"
+                          method="post"
+                          class="attendance-action-form">
+                        {{ check_in_form.hidden_tag() }}
+                        <input type="hidden" name="next" value="{{ request.path }}">
+                        <button type="submit" class="btn-primary">Check In</button>
+                    </form>
+                {% endif %}
+            </div>
             <br>
             <h2 style="text-align:center;">
                 Hardware List

--- a/app/templates/hardware_list.html
+++ b/app/templates/hardware_list.html
@@ -3,7 +3,9 @@
     <div class="page">
         <div class="section live-queue">
             <div class="attendance-card-inline">
-                <h3>Wormhole Attendance</h3>
+                <h3>
+                    Wormhole Attendance
+                </h3>
                 {% if attendance_session %}
                     <p>
                         Checked in since {{ attendance_session.checked_in_at|datetime_pacific("%I:%M %p") }}.
@@ -14,16 +16,22 @@
                           class="attendance-action-form">
                         {{ check_out_form.hidden_tag() }}
                         <input type="hidden" name="next" value="{{ request.path }}">
-                        <button type="submit" class="btn-delete">Check Out</button>
+                        <button type="submit" class="btn-delete">
+                            Check Out
+                        </button>
                     </form>
                 {% else %}
-                    <p>Check in when you are present and available to help students.</p>
+                    <p>
+                        Check in when you are present and available to help students.
+                    </p>
                     <form action="{{ url_for('attendance.check_in') }}"
                           method="post"
                           class="attendance-action-form">
                         {{ check_in_form.hidden_tag() }}
                         <input type="hidden" name="next" value="{{ request.path }}">
-                        <button type="submit" class="btn-primary">Check In</button>
+                        <button type="submit" class="btn-primary">
+                            Check In
+                        </button>
                     </form>
                 {% endif %}
             </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,7 +10,7 @@
                 For Students
             </h2>
             <p class="index-section-link">
-                <a href="{{ url_for("views.create_ticket_page") }}">Submit a Help Request</a>
+                <a href="{{ url_for('views.create_ticket_page') }}">Submit a Help Request</a>
             </p>
             <p class="index-section-link">
                 <a href="https://oregonstate.zoom.us/j/95601298258">Join Zoom Meeting</a>
@@ -29,7 +29,7 @@
             </h2>
             {% if current_user.is_anonymous %}
                 <p class="index-section-link">
-                    <a href="{{ url_for("views.assistant_login") }}">Log In</a>
+                    <a href="{{ url_for('views.assistant_login') }}">Log In</a>
                 </p>
             {% else %}
                 <p class="index-section-link">
@@ -79,7 +79,7 @@
                 </p>
                 <p>
                     If you or your group needs help with a physics question, send a request to the queue.
-                    In person, use the box on your table. Online, use this <a href="{{ url_for("views.create_ticket_page") }}">link</a>.
+                    In person, use the box on your table. Online, use this <a href="{{ url_for('views.create_ticket_page') }}">link</a>.
                     Only one person in the group needs to enter the request, and only one time for each
                     question, please. You can see your place in the help queue using the Live Queue link at
                     the top of the page. Multiple requests for a question won’t get you help any faster, and

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -31,7 +31,7 @@
                     {{ form.submit() }}
                 </p>
                 <p style="text-align:center">
-                    <a href="{{ url_for("auth.reset_password_request") }}">Reset Password</a>
+                    <a href="{{ url_for('auth.reset_password_request') }}">Reset Password</a>
                 </p>
             </form>
         </div>

--- a/app/templates/pastticket.html
+++ b/app/templates/pastticket.html
@@ -44,7 +44,7 @@
                 </button>
             </form>
             <div style="margin-top: 20px;">
-                <a href="{{ url_for("views.queue") }}">Back to Queue</a>
+                <a href="{{ url_for('views.queue') }}">Back to Queue</a>
             </div>
         </div>
     </div>

--- a/app/templates/queue.html
+++ b/app/templates/queue.html
@@ -33,6 +33,58 @@
                     </form>
                 </div>
             {% endif %}
+            {% if user.is_admin %}
+                <div class="subsection attendance-queue-panel">
+                    <h3>
+                        Attendance Snapshot
+                    </h3>
+                    <p>
+                        <a href="{{ url_for('attendance.dashboard') }}">Open full attendance dashboard</a>
+                    </p>
+                    {% if attendance_summary %}
+                        <div class="attendance-summary-inline">
+                            <span>Present: {{ attendance_summary.present }}</span>
+                            <span>Idle: {{ attendance_summary.idle }}</span>
+                            <span>Stale: {{ attendance_summary.stale }}</span>
+                            <span>Missing: {{ attendance_summary.missing }}</span>
+                        </div>
+                    {% endif %}
+                    {% if attendance_rows %}
+                        <table class="attendance-table">
+                            <thead>
+                                <tr>
+                                    <th>Assistant</th>
+                                    <th>Shift</th>
+                                    <th>Last Active</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for row in attendance_rows %}
+                                    <tr>
+                                        <td>{{ row.user.name or row.user.username }}</td>
+                                        <td>{{ row.schedule }}</td>
+                                        <td>
+                                            {% if row.last_seen_at %}
+                                                {{ row.last_seen_at|datetime_pacific("%I:%M %p") }}
+                                            {% else %}
+                                                —
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            <span class="attendance-status attendance-status-{{ row.status_slug }}">
+                                                {{ row.status }}
+                                            </span>
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    {% else %}
+                        <p>No scheduled assistants or checked-in assistants right now.</p>
+                    {% endif %}
+                </div>
+            {% endif %}
             <div class="subsection">
                 <h3>
                     Open Tickets

--- a/app/templates/queue.html
+++ b/app/templates/queue.html
@@ -11,7 +11,7 @@
             </h2>
             {% if user.is_admin %}
                 <div class="queue-admin-actions">
-                    <form action="{{ url_for("views.flush") }}"
+                    <form action="{{ url_for('views.flush') }}"
                           method="post"
                           class="queue-admin-action-form">
                         {{ flush_form.hidden_tag() }}
@@ -21,7 +21,7 @@
                             Flush Queue
                         </button>
                     </form>
-                    <form action="{{ url_for("views.clear_queue") }}"
+                    <form action="{{ url_for('views.clear_queue') }}"
                           method="post"
                           class="queue-admin-action-form">
                         {{ clear_form.hidden_tag() }}
@@ -53,17 +53,29 @@
                         <table class="attendance-table">
                             <thead>
                                 <tr>
-                                    <th>Assistant</th>
-                                    <th>Shift</th>
-                                    <th>Last Active</th>
-                                    <th>Status</th>
+                                    <th>
+                                        Assistant
+                                    </th>
+                                    <th>
+                                        Shift
+                                    </th>
+                                    <th>
+                                        Last Active
+                                    </th>
+                                    <th>
+                                        Status
+                                    </th>
                                 </tr>
                             </thead>
                             <tbody>
                                 {% for row in attendance_rows %}
                                     <tr>
-                                        <td>{{ row.user.name or row.user.username }}</td>
-                                        <td>{{ row.schedule }}</td>
+                                        <td>
+                                            {{ row.user.name or row.user.username }}
+                                        </td>
+                                        <td>
+                                            {{ row.schedule }}
+                                        </td>
                                         <td>
                                             {% if row.last_seen_at %}
                                                 {{ row.last_seen_at|datetime_pacific("%I:%M %p") }}
@@ -81,7 +93,9 @@
                             </tbody>
                         </table>
                     {% else %}
-                        <p>No scheduled assistants or checked-in assistants right now.</p>
+                        <p>
+                            No scheduled assistants or checked-in assistants right now.
+                        </p>
                     {% endif %}
                 </div>
             {% endif %}
@@ -128,7 +142,7 @@
                 </ul>
             </div>
             <div class="queue-back-link">
-                <a href="{{ url_for("views.hardware_list") }}">Back to Hardware List</a>
+                <a href="{{ url_for('views.hardware_list') }}">Back to Hardware List</a>
             </div>
         </div>
     </div>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -5,7 +5,7 @@
             <h1>
                 New User Registration
             </h1>
-            <form action="{{ url_for("users.users_add") }}" method="post" novalidate>
+            <form action="{{ url_for('users.users_add') }}" method="post" novalidate>
                 {{ form.hidden_tag() }}
                 <p>
                     {{ form.first_name.label }}

--- a/app/templates/userpage.html
+++ b/app/templates/userpage.html
@@ -40,6 +40,56 @@
                 </h4>
             {% endif %}
         </div>
+        <div class="section attendance-card">
+            <h2 style="text-align:center">
+                Wormhole Attendance
+            </h2>
+            {% if current_user.username == user.username %}
+                {% if attendance_session %}
+                    <p class="attendance-card-text">
+                        You are checked in.
+                        <br>
+                        Status: <strong>{{ attendance_status }}</strong>
+                        <br>
+                        Checked in: {{ attendance_session.checked_in_at|datetime_pacific("%I:%M %p") }}
+                        <br>
+                        Last active: {{ attendance_session.last_seen_at|datetime_pacific("%I:%M %p") }}
+                    </p>
+                    <form action="{{ url_for('attendance.check_out') }}"
+                          method="post"
+                          class="attendance-action-form">
+                        {{ check_out_form.hidden_tag() }}
+                        <input type="hidden" name="next" value="{{ request.path }}">
+                        <button type="submit" class="btn-delete">Check Out</button>
+                    </form>
+                {% else %}
+                    <p class="attendance-card-text">
+                        Check in when you are physically present and ready to help students.
+                    </p>
+                    <form action="{{ url_for('attendance.check_in') }}"
+                          method="post"
+                          class="attendance-action-form">
+                        {{ check_in_form.hidden_tag() }}
+                        <input type="hidden" name="next" value="{{ request.path }}">
+                        <button type="submit" class="btn-primary">Check In</button>
+                    </form>
+                {% endif %}
+            {% else %}
+                {% if attendance_session %}
+                    <p class="attendance-card-text">
+                        {{ user.name or user.username }} is checked in.
+                        <br>
+                        Status: <strong>{{ attendance_status }}</strong>
+                        <br>
+                        Last active: {{ attendance_session.last_seen_at|datetime_pacific("%I:%M %p") }}
+                    </p>
+                {% else %}
+                    <p class="attendance-card-text">
+                        {{ user.name or user.username }} is not currently checked in.
+                    </p>
+                {% endif %}
+            {% endif %}
+        </div>
         <div class="section profile">
             <h2 style="text-align:center">
                 Profile
@@ -66,6 +116,9 @@
                 <!--<p><a href="{{ url_for('views.changepass') }}">Change User Password</a></p>-->
                 <p style="margin:10px">
                     <a href="{{ url_for("views.queue") }}">Queue</a>
+                </p>
+                <p style="margin:10px">
+                    <a href="{{ url_for("attendance.dashboard") }}">Attendance</a>
                 </p>
                 <p style="margin:10px">
                     <a href="{{ url_for("views.archive") }}">Archive</a>

--- a/app/templates/userpage.html
+++ b/app/templates/userpage.html
@@ -60,7 +60,9 @@
                           class="attendance-action-form">
                         {{ check_out_form.hidden_tag() }}
                         <input type="hidden" name="next" value="{{ request.path }}">
-                        <button type="submit" class="btn-delete">Check Out</button>
+                        <button type="submit" class="btn-delete">
+                            Check Out
+                        </button>
                     </form>
                 {% else %}
                     <p class="attendance-card-text">
@@ -71,7 +73,9 @@
                           class="attendance-action-form">
                         {{ check_in_form.hidden_tag() }}
                         <input type="hidden" name="next" value="{{ request.path }}">
-                        <button type="submit" class="btn-primary">Check In</button>
+                        <button type="submit" class="btn-primary">
+                            Check In
+                        </button>
                     </form>
                 {% endif %}
             {% else %}
@@ -103,7 +107,7 @@
                 <b>Administrator: </b>{{ user.is_admin }}
                 <br>
                 {% if current_user.username==user.username or current_user.is_admin %}
-                    <a href="{{ url_for("views.changepass") }}">Change Password</a>
+                    <a href="{{ url_for('views.changepass') }}">Change Password</a>
                 {% endif %}
             </p>
             {% if current_user.is_admin %}
@@ -111,23 +115,23 @@
                     Admin Utilities
                 </h3>
                 <p style="margin:10px">
-                    <a href="{{ url_for("views.register") }}">Register New User</a>
+                    <a href="{{ url_for('views.register') }}">Register New User</a>
                 </p>
                 <!--<p><a href="{{ url_for('views.changepass') }}">Change User Password</a></p>-->
                 <p style="margin:10px">
-                    <a href="{{ url_for("views.queue") }}">Queue</a>
+                    <a href="{{ url_for('views.queue') }}">Queue</a>
                 </p>
                 <p style="margin:10px">
-                    <a href="{{ url_for("attendance.dashboard") }}">Attendance</a>
+                    <a href="{{ url_for('attendance.dashboard') }}">Attendance</a>
                 </p>
                 <p style="margin:10px">
-                    <a href="{{ url_for("views.archive") }}">Archive</a>
+                    <a href="{{ url_for('views.archive') }}">Archive</a>
                 </p>
                 <p style="margin:10px">
-                    <a href="{{ url_for("views.register_batch") }}">Register Users in Batch</a>
+                    <a href="{{ url_for('views.register_batch') }}">Register Users in Batch</a>
                 </p>
                 <p style="margin:10px">
-                    <a href="{{ url_for("views.user_list") }}">WA List</a>
+                    <a href="{{ url_for('views.user_list') }}">WA List</a>
                 </p>
             {% endif %}
         </div>

--- a/migrations/versions/b7f2c1d4a112_add_attendance_feature.py
+++ b/migrations/versions/b7f2c1d4a112_add_attendance_feature.py
@@ -58,7 +58,9 @@ def upgrade():
         sa.Column("status", sa.String(length=20), nullable=False),
         sa.Column("check_in_source", sa.String(length=50), nullable=False),
         sa.Column("notes", sa.String(length=255), nullable=True),
-        sa.ForeignKeyConstraint(["shift_id"], ["attendance_shifts.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["shift_id"], ["attendance_shifts.id"], ondelete="SET NULL"
+        ),
         sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
@@ -138,7 +140,9 @@ def downgrade():
         batch_op.drop_index(batch_op.f("ix_attendance_activities_user_id"))
         batch_op.drop_index(batch_op.f("ix_attendance_activities_ticket_id"))
         batch_op.drop_index(batch_op.f("ix_attendance_activities_created_at"))
-        batch_op.drop_index(batch_op.f("ix_attendance_activities_attendance_session_id"))
+        batch_op.drop_index(
+            batch_op.f("ix_attendance_activities_attendance_session_id")
+        )
         batch_op.drop_index(batch_op.f("ix_attendance_activities_activity_type"))
     op.drop_table("attendance_activities")
 

--- a/migrations/versions/b7f2c1d4a112_add_attendance_feature.py
+++ b/migrations/versions/b7f2c1d4a112_add_attendance_feature.py
@@ -1,0 +1,157 @@
+"""add attendance feature
+
+Revision ID: b7f2c1d4a112
+Revises: 9d200740c874
+Create Date: 2026-04-23 23:45:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b7f2c1d4a112"
+down_revision = "9d200740c874"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "attendance_shifts",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("day_of_week", sa.Integer(), nullable=False),
+        sa.Column("start_time", sa.Time(), nullable=False),
+        sa.Column("end_time", sa.Time(), nullable=False),
+        sa.Column("location", sa.String(length=100), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("attendance_shifts", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_attendance_shifts_created_at"),
+            ["created_at"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_attendance_shifts_day_of_week"),
+            ["day_of_week"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_attendance_shifts_user_id"),
+            ["user_id"],
+            unique=False,
+        )
+
+    op.create_table(
+        "attendance_sessions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("shift_id", sa.Integer(), nullable=True),
+        sa.Column("checked_in_at", sa.DateTime(), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(), nullable=False),
+        sa.Column("checked_out_at", sa.DateTime(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("check_in_source", sa.String(length=50), nullable=False),
+        sa.Column("notes", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(["shift_id"], ["attendance_shifts.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("attendance_sessions", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_attendance_sessions_checked_in_at"),
+            ["checked_in_at"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_attendance_sessions_last_seen_at"),
+            ["last_seen_at"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_attendance_sessions_shift_id"),
+            ["shift_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_attendance_sessions_status"),
+            ["status"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_attendance_sessions_user_id"),
+            ["user_id"],
+            unique=False,
+        )
+
+    op.create_table(
+        "attendance_activities",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("attendance_session_id", sa.Integer(), nullable=True),
+        sa.Column("ticket_id", sa.Integer(), nullable=True),
+        sa.Column("activity_type", sa.String(length=50), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["attendance_session_id"], ["attendance_sessions.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["ticket_id"], ["tickets.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("attendance_activities", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_attendance_activities_activity_type"),
+            ["activity_type"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_attendance_activities_attendance_session_id"),
+            ["attendance_session_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_attendance_activities_created_at"),
+            ["created_at"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_attendance_activities_ticket_id"),
+            ["ticket_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_attendance_activities_user_id"),
+            ["user_id"],
+            unique=False,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("attendance_activities", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_attendance_activities_user_id"))
+        batch_op.drop_index(batch_op.f("ix_attendance_activities_ticket_id"))
+        batch_op.drop_index(batch_op.f("ix_attendance_activities_created_at"))
+        batch_op.drop_index(batch_op.f("ix_attendance_activities_attendance_session_id"))
+        batch_op.drop_index(batch_op.f("ix_attendance_activities_activity_type"))
+    op.drop_table("attendance_activities")
+
+    with op.batch_alter_table("attendance_sessions", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_attendance_sessions_user_id"))
+        batch_op.drop_index(batch_op.f("ix_attendance_sessions_status"))
+        batch_op.drop_index(batch_op.f("ix_attendance_sessions_shift_id"))
+        batch_op.drop_index(batch_op.f("ix_attendance_sessions_last_seen_at"))
+        batch_op.drop_index(batch_op.f("ix_attendance_sessions_checked_in_at"))
+    op.drop_table("attendance_sessions")
+
+    with op.batch_alter_table("attendance_shifts", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_attendance_shifts_user_id"))
+        batch_op.drop_index(batch_op.f("ix_attendance_shifts_day_of_week"))
+        batch_op.drop_index(batch_op.f("ix_attendance_shifts_created_at"))
+    op.drop_table("attendance_shifts")

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "htmlhint": "^0.16.3",
-        "stylelint": "^16.25.0",
+        "stylelint": "^16.26.1",
         "stylelint-config-standard": "^39.0.1"
       }
     },
@@ -37,34 +37,28 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@cacheable/memoize": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@cacheable/memoize/-/memoize-2.0.3.tgz",
-      "integrity": "sha512-hl9wfQgpiydhQEIv7fkjEzTGE+tcosCXLKFDO707wYJ/78FVOlowb36djex5GdbSyeHnG62pomYLMuV/OT8Pbw==",
-      "dev": true,
-      "dependencies": {
-        "@cacheable/utils": "^2.0.3"
-      }
-    },
     "node_modules/@cacheable/memory": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.4.tgz",
-      "integrity": "sha512-cCmJKCKlT1t7hNBI1+gFCwmKFd9I4pS3zqBeNGXTSODnpa0EeDmORHY8oEMTuozfdg3cgsVh8ojLaPYb6eC7Cg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+      "integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cacheable/utils": "^2.2.0",
-        "@keyv/bigmap": "^1.1.0",
-        "hookified": "^1.12.2",
-        "keyv": "^5.5.3"
+        "@cacheable/utils": "^2.4.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@cacheable/utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.2.0.tgz",
-      "integrity": "sha512-7xaQayO3msdVcxXLYcLU5wDqJBNdQcPPPHr6mdTEIQI7N7TbtSVVTpWOTfjyhg0L6AQwQdq7miKdWtTDBoBldQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "keyv": "^5.5.3"
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
@@ -82,12 +76,36 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
@@ -105,7 +123,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -166,25 +183,28 @@
       }
     },
     "node_modules/@keyv/bigmap": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.1.0.tgz",
-      "integrity": "sha512-MX7XIUNwVRK+hjZcAbNJ0Z8DREo+Weu9vinBOjGU1thEi9F6vPhICzBbk4CCf3eEefKRz7n6TfZXwUFZTSgj8Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "hookified": "^1.12.2"
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "keyv": "^5.5.3"
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@keyv/serialize": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -320,17 +340,17 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.1.1.tgz",
-      "integrity": "sha512-LmF4AXiSNdiRbI2UjH8pAp9NIXxeQsTotpEaegPiDcnN0YPygDJDV3l/Urc0mL72JWdATEorKqIHEx55nDlONg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.4.tgz",
+      "integrity": "sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@cacheable/memoize": "^2.0.3",
-        "@cacheable/memory": "^2.0.3",
-        "@cacheable/utils": "^2.1.0",
-        "hookified": "^1.12.2",
-        "keyv": "^5.5.3",
-        "qified": "^0.5.0"
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.9.0"
       }
     },
     "node_modules/callsites": {
@@ -433,13 +453,14 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -567,12 +588,13 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.4.tgz",
-      "integrity": "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+      "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.13"
+        "flat-cache": "^6.1.20"
       }
     },
     "node_modules/fill-range": {
@@ -588,21 +610,23 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "6.1.18",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.18.tgz",
-      "integrity": "sha512-JUPnFgHMuAVmLmoH9/zoZ6RHOt5n9NlUw/sDXsTbROJ2SFoS2DS4s+swAV6UTeTbGH/CAsZIE6M8TaG/3jVxgQ==",
+      "version": "6.1.22",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
+      "integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "cacheable": "^2.1.0",
-        "flatted": "^3.3.3",
-        "hookified": "^1.12.0"
+        "cacheable": "^2.3.4",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -756,11 +780,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hookified": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.2.tgz",
-      "integrity": "sha512-aokUX1VdTpI0DUsndvW+OiwmBpKCu/NgRsSSkuSY0zq8PY6Q6a+lmOfAFDXAAOtBqJELvcWY9L1EVtzjbQcMdg==",
-      "dev": true
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-tags": {
       "version": "3.3.1",
@@ -960,11 +998,11 @@
       "dev": true
     },
     "node_modules/keyv": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
-      "integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -1007,10 +1045,11 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "dev": true
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/meow": {
       "version": "13.2.0",
@@ -1241,7 +1280,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -1288,7 +1326,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -1304,16 +1341,24 @@
       "dev": true
     },
     "node_modules/qified": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/qified/-/qified-0.5.1.tgz",
-      "integrity": "sha512-+BtFN3dCP+IaFA6IYNOu/f/uK1B8xD2QWyOeCse0rjtAebBmkzgd2d1OAXi3ikAzJMIBSdzZDNZ3wZKEUDQs5w==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.9.1.tgz",
+      "integrity": "sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "hookified": "^1.12.2"
+        "hookified": "^2.1.1"
       },
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.1.1.tgz",
+      "integrity": "sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -1469,9 +1514,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "16.25.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.25.0.tgz",
-      "integrity": "sha512-Li0avYWV4nfv1zPbdnxLYBGq4z8DVZxbRgx4Kn6V+Uftz1rMoF1qiEI3oL4kgWqyYgCgs7gT5maHNZ82Gk03vQ==",
+      "version": "16.26.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
+      "integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
       "dev": true,
       "funding": [
         {
@@ -1483,8 +1528,10 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
         "@csstools/css-tokenizer": "^3.0.4",
         "@csstools/media-query-list-parser": "^4.0.3",
         "@csstools/selector-specificity": "^5.0.0",
@@ -1497,7 +1544,7 @@
         "debug": "^4.4.3",
         "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^10.1.4",
+        "file-entry-cache": "^11.1.1",
         "global-modules": "^2.0.0",
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
@@ -1567,6 +1614,7 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "stylelint-config-recommended": "^17.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "devDependencies": {
     "htmlhint": "^0.16.3",
-    "stylelint": "^16.25.0",
+    "stylelint": "^16.26.1",
     "stylelint-config-standard": "^39.0.1"
   }
 }

--- a/tests/test_attendance.py
+++ b/tests/test_attendance.py
@@ -175,6 +175,30 @@ def test_admin_can_create_attendance_shift(test_client, test_app):
         assert shift.is_active is True
 
 
+def test_admin_cannot_assign_attendance_shift_to_admin_user(test_client, test_app):
+    """The server should reject crafted requests that schedule admin users."""
+    with test_app.app_context():
+        admin = _create_user("server_shift_admin", is_admin=True)
+        other_admin = _create_user("other_shift_admin", is_admin=True)
+        _login_as(test_client, admin)
+
+        response = test_client.post(
+            "/attendance/shifts/add",
+            data={
+                "user_id": str(other_admin.id),
+                "day_of_week": "0",
+                "start_time": "09:00",
+                "end_time": "17:00",
+                "location": "Wormhole Desk",
+            },
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 200
+        assert b"Admin users cannot be assigned attendance shifts." in response.data
+        assert AttendanceShift.query.filter_by(user_id=other_admin.id).count() == 0
+
+
 def test_non_admin_cannot_create_attendance_shift(test_client, test_app):
     """Regular assistants cannot manage the recurring attendance schedule."""
     with test_app.app_context():

--- a/tests/test_attendance.py
+++ b/tests/test_attendance.py
@@ -1,0 +1,112 @@
+from datetime import datetime, time, timezone
+
+from app import db
+from app.attendance_utils import PACIFIC_TZ
+from app.models import AttendanceActivity, AttendanceSession, AttendanceShift, Ticket, User
+
+
+def _login_as(test_client, user):
+    with test_client.session_transaction() as sess:
+        sess["user_id"] = user.id
+        sess["is_admin"] = user.is_admin
+
+
+def test_attendance_check_in_heartbeat_and_check_out(test_client, test_app):
+    """Assistants can check in, send heartbeat, and check out with activity logged."""
+    with test_app.app_context():
+        user = User(username="attendant", email="attendant@test.com", is_admin=False)
+        user.set_password("pass")
+        db.session.add(user)
+        db.session.commit()
+        _login_as(test_client, user)
+
+        response = test_client.post("/attendance/check-in", follow_redirects=True)
+        assert response.status_code == 200
+        assert b"You are now checked in to the Wormhole." in response.data
+
+        attendance_session = AttendanceSession.query.filter_by(user_id=user.id).one()
+        assert attendance_session.status == "active"
+        assert attendance_session.checked_out_at is None
+        assert AttendanceActivity.query.filter_by(
+            user_id=user.id, activity_type="check_in"
+        ).count() == 1
+
+        first_seen = attendance_session.last_seen_at
+        heartbeat_response = test_client.post("/attendance/heartbeat")
+        assert heartbeat_response.status_code == 200
+        assert heartbeat_response.get_json()["checked_in"] is True
+
+        db.session.refresh(attendance_session)
+        assert attendance_session.last_seen_at >= first_seen
+
+        response = test_client.post("/attendance/check-out", follow_redirects=True)
+        assert response.status_code == 200
+        assert b"You have checked out of the Wormhole." in response.data
+
+        db.session.refresh(attendance_session)
+        assert attendance_session.status == "checked_out"
+        assert attendance_session.checked_out_at is not None
+        assert AttendanceActivity.query.filter_by(
+            user_id=user.id, activity_type="check_out"
+        ).count() == 1
+
+
+def test_attendance_dashboard_shows_scheduled_missing_assistant(test_client, test_app):
+    """Admins can see scheduled assistants who have not checked in."""
+    with test_app.app_context():
+        admin = User(username="attendance_admin", email="aa@test.com", is_admin=True)
+        assistant = User(
+            username="scheduled_helper",
+            email="scheduled@test.com",
+            name="Scheduled Helper",
+            is_admin=False,
+        )
+        admin.set_password("pass")
+        assistant.set_password("pass")
+        db.session.add_all([admin, assistant])
+        db.session.commit()
+
+        now_pacific = datetime.now(timezone.utc).astimezone(PACIFIC_TZ)
+        shift = AttendanceShift(
+            user_id=assistant.id,
+            day_of_week=now_pacific.weekday(),
+            start_time=time(0, 0),
+            end_time=time(23, 59),
+            location="Wormhole",
+            is_active=True,
+        )
+        db.session.add(shift)
+        db.session.commit()
+
+        _login_as(test_client, admin)
+
+        response = test_client.get("/attendance/")
+        assert response.status_code == 200
+        assert b"Scheduled Helper" in response.data
+        assert b"Missing" in response.data
+
+
+def test_ticket_claim_creates_attendance_activity(test_client, test_app):
+    """Claiming a ticket records queue activity for the checked-in assistant."""
+    with test_app.app_context():
+        user = User(username="claim_helper", email="claim@test.com", is_admin=False)
+        user.set_password("pass")
+        ticket = Ticket(
+            student_name="Queue Student",
+            table="Zoom",
+            physics_course="Ph 211",
+            status="live",
+        )
+        db.session.add_all([user, ticket])
+        db.session.commit()
+        _login_as(test_client, user)
+
+        test_client.post("/attendance/check-in", follow_redirects=True)
+        response = test_client.get(f"/getnewticket/{user.username}", follow_redirects=False)
+        assert response.status_code == 302
+
+        activity = AttendanceActivity.query.filter_by(
+            user_id=user.id, activity_type="ticket_claimed"
+        ).one()
+        assert activity.ticket_id == ticket.id
+        assert "Claimed ticket" in activity.description

--- a/tests/test_attendance.py
+++ b/tests/test_attendance.py
@@ -5,7 +5,13 @@ from app.attendance_utils import (
     PACIFIC_TZ,
     attendance_status_for_session,
 )
-from app.models import AttendanceActivity, AttendanceSession, AttendanceShift, Ticket, User
+from app.models import (
+    AttendanceActivity,
+    AttendanceSession,
+    AttendanceShift,
+    Ticket,
+    User,
+)
 
 
 def _login_as(test_client, user):
@@ -55,9 +61,12 @@ def test_attendance_check_in_heartbeat_and_check_out(test_client, test_app):
         attendance_session = AttendanceSession.query.filter_by(user_id=user.id).one()
         assert attendance_session.status == "active"
         assert attendance_session.checked_out_at is None
-        assert AttendanceActivity.query.filter_by(
-            user_id=user.id, activity_type="check_in"
-        ).count() == 1
+        assert (
+            AttendanceActivity.query.filter_by(
+                user_id=user.id, activity_type="check_in"
+            ).count()
+            == 1
+        )
 
         first_seen = attendance_session.last_seen_at
         heartbeat_response = test_client.post("/attendance/heartbeat")
@@ -74,9 +83,12 @@ def test_attendance_check_in_heartbeat_and_check_out(test_client, test_app):
         db.session.refresh(attendance_session)
         assert attendance_session.status == "checked_out"
         assert attendance_session.checked_out_at is not None
-        assert AttendanceActivity.query.filter_by(
-            user_id=user.id, activity_type="check_out"
-        ).count() == 1
+        assert (
+            AttendanceActivity.query.filter_by(
+                user_id=user.id, activity_type="check_out"
+            ).count()
+            == 1
+        )
 
 
 def test_duplicate_check_in_does_not_create_duplicate_active_sessions(
@@ -88,19 +100,27 @@ def test_duplicate_check_in_does_not_create_duplicate_active_sessions(
         _login_as(test_client, user)
 
         first_response = test_client.post("/attendance/check-in", follow_redirects=True)
-        second_response = test_client.post("/attendance/check-in", follow_redirects=True)
+        second_response = test_client.post(
+            "/attendance/check-in", follow_redirects=True
+        )
 
         assert first_response.status_code == 200
         assert second_response.status_code == 200
         assert b"You are already checked in to the Wormhole." in second_response.data
-        assert AttendanceSession.query.filter_by(
-            user_id=user.id,
-            status="active",
-        ).count() == 1
-        assert AttendanceActivity.query.filter_by(
-            user_id=user.id,
-            activity_type="check_in",
-        ).count() == 1
+        assert (
+            AttendanceSession.query.filter_by(
+                user_id=user.id,
+                status="active",
+            ).count()
+            == 1
+        )
+        assert (
+            AttendanceActivity.query.filter_by(
+                user_id=user.id,
+                activity_type="check_in",
+            ).count()
+            == 1
+        )
 
 
 def test_heartbeat_without_active_session_is_safe(test_client, test_app):
@@ -264,7 +284,9 @@ def test_unscheduled_check_in_is_allowed_and_visible_to_admin(test_client, test_
         assistant = _create_user("unscheduled_helper", name="Unscheduled Helper")
         _login_as(test_client, assistant)
 
-        check_in_response = test_client.post("/attendance/check-in", follow_redirects=True)
+        check_in_response = test_client.post(
+            "/attendance/check-in", follow_redirects=True
+        )
         assert check_in_response.status_code == 200
 
         attendance_session = AttendanceSession.query.filter_by(
@@ -340,7 +362,9 @@ def test_ticket_claim_creates_attendance_activity(test_client, test_app):
         _login_as(test_client, user)
 
         test_client.post("/attendance/check-in", follow_redirects=True)
-        response = test_client.get(f"/getnewticket/{user.username}", follow_redirects=False)
+        response = test_client.get(
+            f"/getnewticket/{user.username}", follow_redirects=False
+        )
         assert response.status_code == 302
 
         activity = AttendanceActivity.query.filter_by(

--- a/tests/test_attendance.py
+++ b/tests/test_attendance.py
@@ -1,7 +1,10 @@
-from datetime import datetime, time, timezone
+from datetime import datetime, time, timedelta, timezone
 
 from app import db
-from app.attendance_utils import PACIFIC_TZ
+from app.attendance_utils import (
+    PACIFIC_TZ,
+    attendance_status_for_session,
+)
 from app.models import AttendanceActivity, AttendanceSession, AttendanceShift, Ticket, User
 
 
@@ -11,13 +14,38 @@ def _login_as(test_client, user):
         sess["is_admin"] = user.is_admin
 
 
+def _create_user(username, *, is_admin=False, name=None):
+    user = User(
+        username=username,
+        email=f"{username}@test.com",
+        name=name,
+        is_admin=is_admin,
+    )
+    user.set_password("pass")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _full_day_shift_for_user(user):
+    now_pacific = datetime.now(timezone.utc).astimezone(PACIFIC_TZ)
+    shift = AttendanceShift(
+        user_id=user.id,
+        day_of_week=now_pacific.weekday(),
+        start_time=time(0, 0),
+        end_time=time(23, 59),
+        location="Wormhole",
+        is_active=True,
+    )
+    db.session.add(shift)
+    db.session.commit()
+    return shift
+
+
 def test_attendance_check_in_heartbeat_and_check_out(test_client, test_app):
     """Assistants can check in, send heartbeat, and check out with activity logged."""
     with test_app.app_context():
-        user = User(username="attendant", email="attendant@test.com", is_admin=False)
-        user.set_password("pass")
-        db.session.add(user)
-        db.session.commit()
+        user = _create_user("attendant")
         _login_as(test_client, user)
 
         response = test_client.post("/attendance/check-in", follow_redirects=True)
@@ -51,33 +79,158 @@ def test_attendance_check_in_heartbeat_and_check_out(test_client, test_app):
         ).count() == 1
 
 
+def test_duplicate_check_in_does_not_create_duplicate_active_sessions(
+    test_client, test_app
+):
+    """Double-clicking check-in should not create multiple open sessions."""
+    with test_app.app_context():
+        user = _create_user("duplicate_helper")
+        _login_as(test_client, user)
+
+        first_response = test_client.post("/attendance/check-in", follow_redirects=True)
+        second_response = test_client.post("/attendance/check-in", follow_redirects=True)
+
+        assert first_response.status_code == 200
+        assert second_response.status_code == 200
+        assert b"You are already checked in to the Wormhole." in second_response.data
+        assert AttendanceSession.query.filter_by(
+            user_id=user.id,
+            status="active",
+        ).count() == 1
+        assert AttendanceActivity.query.filter_by(
+            user_id=user.id,
+            activity_type="check_in",
+        ).count() == 1
+
+
+def test_heartbeat_without_active_session_is_safe(test_client, test_app):
+    """Heartbeat should be harmless when a logged-in user is not checked in."""
+    with test_app.app_context():
+        user = _create_user("heartbeat_only")
+        _login_as(test_client, user)
+
+        response = test_client.post("/attendance/heartbeat")
+
+        assert response.status_code == 200
+        assert response.get_json() == {"ok": True, "checked_in": False}
+        assert AttendanceSession.query.filter_by(user_id=user.id).count() == 0
+
+
+def test_attendance_requires_login(test_client):
+    """Unauthenticated users should not be able to check in or heartbeat."""
+    check_in_response = test_client.post("/attendance/check-in")
+    heartbeat_response = test_client.post("/attendance/heartbeat")
+
+    assert check_in_response.status_code == 401
+    assert heartbeat_response.status_code == 401
+
+
+def test_admin_can_create_attendance_shift(test_client, test_app):
+    """Admins can create recurring scheduled attendance shifts."""
+    with test_app.app_context():
+        admin = _create_user("shift_admin", is_admin=True)
+        assistant = _create_user("scheduled_assistant", name="Scheduled Assistant")
+        _login_as(test_client, admin)
+
+        response = test_client.post(
+            "/attendance/shifts/add",
+            data={
+                "user_id": str(assistant.id),
+                "day_of_week": "0",
+                "start_time": "09:00",
+                "end_time": "17:00",
+                "location": "Wormhole Desk",
+            },
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 200
+        assert b"Attendance shift added." in response.data
+
+        shift = AttendanceShift.query.filter_by(user_id=assistant.id).one()
+        assert shift.day_of_week == 0
+        assert shift.start_time == time(9, 0)
+        assert shift.end_time == time(17, 0)
+        assert shift.location == "Wormhole Desk"
+        assert shift.is_active is True
+
+
+def test_non_admin_cannot_create_attendance_shift(test_client, test_app):
+    """Regular assistants cannot manage the recurring attendance schedule."""
+    with test_app.app_context():
+        user = _create_user("regular_helper")
+        other_assistant = _create_user("other_helper")
+        _login_as(test_client, user)
+
+        response = test_client.post(
+            "/attendance/shifts/add",
+            data={
+                "user_id": str(other_assistant.id),
+                "day_of_week": "0",
+                "start_time": "09:00",
+                "end_time": "17:00",
+                "location": "Wormhole",
+            },
+        )
+
+        assert response.status_code == 403
+        assert AttendanceShift.query.filter_by(user_id=other_assistant.id).count() == 0
+
+
+def test_invalid_shift_times_are_rejected(test_client, test_app):
+    """The app should reject shifts whose end time is not after the start time."""
+    with test_app.app_context():
+        admin = _create_user("invalid_shift_admin", is_admin=True)
+        assistant = _create_user("invalid_shift_helper")
+        _login_as(test_client, admin)
+
+        response = test_client.post(
+            "/attendance/shifts/add",
+            data={
+                "user_id": str(assistant.id),
+                "day_of_week": "0",
+                "start_time": "17:00",
+                "end_time": "09:00",
+                "location": "Wormhole",
+            },
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 200
+        assert b"Shift end time must be after the start time." in response.data
+        assert AttendanceShift.query.filter_by(user_id=assistant.id).count() == 0
+
+
+def test_admin_can_soft_delete_attendance_shift(test_client, test_app):
+    """Deleting a shift should deactivate it instead of destroying history."""
+    with test_app.app_context():
+        admin = _create_user("delete_shift_admin", is_admin=True)
+        assistant = _create_user("delete_shift_helper")
+        shift = _full_day_shift_for_user(assistant)
+        shift_id = shift.id
+        _login_as(test_client, admin)
+
+        response = test_client.post(
+            f"/attendance/shifts/{shift_id}/delete",
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 200
+        assert b"Attendance shift removed." in response.data
+        deactivated_shift = db.session.get(AttendanceShift, shift_id)
+        assert deactivated_shift is not None
+        assert deactivated_shift.is_active is False
+
+
 def test_attendance_dashboard_shows_scheduled_missing_assistant(test_client, test_app):
     """Admins can see scheduled assistants who have not checked in."""
     with test_app.app_context():
-        admin = User(username="attendance_admin", email="aa@test.com", is_admin=True)
-        assistant = User(
-            username="scheduled_helper",
-            email="scheduled@test.com",
+        admin = _create_user("attendance_admin", is_admin=True)
+        assistant = _create_user(
+            "scheduled_helper",
             name="Scheduled Helper",
-            is_admin=False,
         )
-        admin.set_password("pass")
-        assistant.set_password("pass")
-        db.session.add_all([admin, assistant])
-        db.session.commit()
-
-        now_pacific = datetime.now(timezone.utc).astimezone(PACIFIC_TZ)
-        shift = AttendanceShift(
-            user_id=assistant.id,
-            day_of_week=now_pacific.weekday(),
-            start_time=time(0, 0),
-            end_time=time(23, 59),
-            location="Wormhole",
-            is_active=True,
-        )
-        db.session.add(shift)
-        db.session.commit()
-
+        _full_day_shift_for_user(assistant)
         _login_as(test_client, admin)
 
         response = test_client.get("/attendance/")
@@ -86,18 +239,103 @@ def test_attendance_dashboard_shows_scheduled_missing_assistant(test_client, tes
         assert b"Missing" in response.data
 
 
+def test_check_in_attaches_to_current_scheduled_shift(test_client, test_app):
+    """A check-in during a matching scheduled shift should link to that shift."""
+    with test_app.app_context():
+        assistant = _create_user("matched_shift_helper")
+        shift = _full_day_shift_for_user(assistant)
+        _login_as(test_client, assistant)
+
+        response = test_client.post("/attendance/check-in", follow_redirects=True)
+
+        assert response.status_code == 200
+        attendance_session = AttendanceSession.query.filter_by(
+            user_id=assistant.id,
+            status="active",
+        ).one()
+        assert attendance_session.shift_id == shift.id
+        assert attendance_session.notes is None
+
+
+def test_unscheduled_check_in_is_allowed_and_visible_to_admin(test_client, test_app):
+    """Coverage helpers should appear even when they check in outside a shift."""
+    with test_app.app_context():
+        admin = _create_user("unscheduled_admin", is_admin=True)
+        assistant = _create_user("unscheduled_helper", name="Unscheduled Helper")
+        _login_as(test_client, assistant)
+
+        check_in_response = test_client.post("/attendance/check-in", follow_redirects=True)
+        assert check_in_response.status_code == 200
+
+        attendance_session = AttendanceSession.query.filter_by(
+            user_id=assistant.id,
+            status="active",
+        ).one()
+        assert attendance_session.shift_id is None
+        assert attendance_session.notes == "Checked in outside a scheduled shift."
+
+        _login_as(test_client, admin)
+        dashboard_response = test_client.get("/attendance/")
+        assert dashboard_response.status_code == 200
+        assert b"Unscheduled Helper" in dashboard_response.data
+        assert b"Unscheduled check-in" in dashboard_response.data
+        assert b"Present" in dashboard_response.data
+
+
+def test_attendance_status_distinguishes_present_idle_and_stale(test_app):
+    """Last-seen timestamps should drive present, idle, and stale status labels."""
+    with test_app.app_context():
+        user = _create_user("status_helper")
+        now = datetime.now(timezone.utc)
+        attendance_session = AttendanceSession(
+            user_id=user.id,
+            checked_in_at=now - timedelta(minutes=30),
+            last_seen_at=now,
+            status="active",
+        )
+        db.session.add(attendance_session)
+        db.session.commit()
+
+        assert attendance_status_for_session(attendance_session, now) == "Present"
+
+        attendance_session.last_seen_at = now - timedelta(minutes=10)
+        assert attendance_status_for_session(attendance_session, now) == "Idle"
+
+        attendance_session.last_seen_at = now - timedelta(minutes=20)
+        assert attendance_status_for_session(attendance_session, now) == "Stale"
+
+        attendance_session.status = "checked_out"
+        attendance_session.checked_out_at = now
+        assert attendance_status_for_session(attendance_session, now) == "Checked out"
+
+
+def test_queue_page_shows_attendance_summary_for_admin(test_client, test_app):
+    """The existing queue dashboard should include a compact attendance snapshot."""
+    with test_app.app_context():
+        admin = _create_user("queue_admin", is_admin=True)
+        assistant = _create_user("queue_missing_helper", name="Queue Missing Helper")
+        _full_day_shift_for_user(assistant)
+        _login_as(test_client, admin)
+
+        response = test_client.get("/queue")
+
+        assert response.status_code == 200
+        assert b"Attendance Snapshot" in response.data
+        assert b"Queue Missing Helper" in response.data
+        assert b"Missing" in response.data
+
+
 def test_ticket_claim_creates_attendance_activity(test_client, test_app):
     """Claiming a ticket records queue activity for the checked-in assistant."""
     with test_app.app_context():
-        user = User(username="claim_helper", email="claim@test.com", is_admin=False)
-        user.set_password("pass")
+        user = _create_user("claim_helper")
         ticket = Ticket(
             student_name="Queue Student",
             table="Zoom",
             physics_course="Ph 211",
             status="live",
         )
-        db.session.add_all([user, ticket])
+        db.session.add(ticket)
         db.session.commit()
         _login_as(test_client, user)
 
@@ -109,4 +347,36 @@ def test_ticket_claim_creates_attendance_activity(test_client, test_app):
             user_id=user.id, activity_type="ticket_claimed"
         ).one()
         assert activity.ticket_id == ticket.id
+        assert activity.attendance_session_id is not None
         assert "Claimed ticket" in activity.description
+
+
+def test_ticket_resolution_creates_attendance_activity(test_client, test_app):
+    """Resolving a ticket should be included in the assistant activity log."""
+    with test_app.app_context():
+        user = _create_user("resolve_helper")
+        ticket = Ticket(
+            student_name="Resolved Student",
+            table="3",
+            physics_course="Ph 212",
+            status="in_progress",
+            wa_id=user.id,
+        )
+        db.session.add(ticket)
+        db.session.commit()
+        _login_as(test_client, user)
+
+        test_client.post("/attendance/check-in", follow_redirects=True)
+        response = test_client.post(
+            f"/api/resolveticket/{ticket.id}",
+            data={"resolve": "helped", "numstudents": "1"},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        activity = AttendanceActivity.query.filter_by(
+            user_id=user.id,
+            ticket_id=ticket.id,
+            activity_type="ticket_resolved",
+        ).one()
+        assert "Resolved ticket" in activity.description


### PR DESCRIPTION
This PR adds an attendance tracking system for Wormhole assistants. It handles check-ins/check-outs, shift scheduling, and activity logging, and comes with an admin dashboard for keeping tabs on staff attendance.

For the data layer, there are three new models; AttendanceShift, AttendanceSession, and AttendanceActivity, tied to the existing User and Ticket records. A new attendance_utils.py file goes alongside them, with helpers for things like time normalization, session management, shift matching, and activity recording.

The forms side adds check-in, check-out, and shift creation forms, all CSRF-protected. There's also a new attendance_bp blueprint wiring up the dashboard, check-in/out endpoints, a heartbeat for live status, and shift management, admin routes are gated appropriately, and the blueprint is registered in the app init.