### PR TITLE
Add weekly archive CLI, utils, and systemd

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -49,11 +49,12 @@ def create_app(testing=False):
         app.config["ENABLE_HSTS"] = False
         app.config["PREFERRED_URL_SCHEME"] = "http"
     elif (
-        not os.environ.get("DATABASE_URL")
+        os.environ.get("REQUIRE_DATABASE_URL") == "1"
+        and not os.environ.get("DATABASE_URL")
         and os.environ.get("ALLOW_SQLITE_FALLBACK") != "1"
     ):
         raise RuntimeError(
-            "DATABASE_URL must be set for non-testing environments. "
+            "DATABASE_URL must be set when REQUIRE_DATABASE_URL=1. "
             "Set ALLOW_SQLITE_FALLBACK=1 only for local development."
         )
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,7 +15,7 @@ migrate = Migrate()
 socketio = SocketIO()
 
 
-def create_app(testing=True):
+def create_app(testing=False):
     """
     Create and configure the Flask application instance.
 
@@ -95,6 +95,7 @@ def create_app(testing=True):
     # The '# noqa: F401' tells Ruff that although the import isn't used directly
     # in this file, it is intentional (for registering models and events).
     from app import models  # noqa: F401
+    from app.archive_utils import register_archive_cli
     from app.routes import queue_events  # noqa: F401
     from app.routes.auth import auth_bp
     from app.routes.error import error_bp
@@ -105,6 +106,7 @@ def create_app(testing=True):
     app.register_blueprint(views_bp)
     app.register_blueprint(tickets_bp)
     app.register_blueprint(error_bp)
+    register_archive_cli(app)
 
     # ---------------------------------------------------
     # Health Check Route

--- a/app/archive_utils.py
+++ b/app/archive_utils.py
@@ -269,39 +269,40 @@ def append_weekly_archive(
     )
 
     existing_keys = _existing_archive_keys(archive_path)
-    rows: list[list[object]] = []
+    rows_written = 0
     skipped = 0
+    archive_file = None
+    writer = None
 
-    for ticket in tickets:
-        row = ticket_archive_row(ticket)
-        key = _row_dedupe_key(row)
-        if key in existing_keys:
-            skipped += 1
-            continue
-        existing_keys.add(key)
-        rows.append(row)
+    try:
+        for ticket in tickets:
+            row = ticket_archive_row(ticket)
+            key = _row_dedupe_key(row)
+            if key in existing_keys:
+                skipped += 1
+                continue
 
-    if not rows:
-        return ArchiveWriteResult(
-            path=archive_path,
-            rows_written=0,
-            rows_skipped=skipped,
-            start_utc=start_utc,
-            end_utc=end_utc,
-        )
+            existing_keys.add(key)
 
-    archive_path.parent.mkdir(parents=True, exist_ok=True)
-    needs_header = not archive_path.exists() or archive_path.stat().st_size == 0
+            if writer is None:
+                archive_path.parent.mkdir(parents=True, exist_ok=True)
+                needs_header = (
+                    not archive_path.exists() or archive_path.stat().st_size == 0
+                )
+                archive_file = archive_path.open("a", encoding="utf-8", newline="")
+                writer = csv.writer(archive_file)
+                if needs_header:
+                    writer.writerow(ARCHIVE_HEADERS)
 
-    with archive_path.open("a", encoding="utf-8", newline="") as archive_file:
-        writer = csv.writer(archive_file)
-        if needs_header:
-            writer.writerow(ARCHIVE_HEADERS)
-        writer.writerows(rows)
+            writer.writerow(row)
+            rows_written += 1
+    finally:
+        if archive_file is not None:
+            archive_file.close()
 
     return ArchiveWriteResult(
         path=archive_path,
-        rows_written=len(rows),
+        rows_written=rows_written,
         rows_skipped=skipped,
         start_utc=start_utc,
         end_utc=end_utc,

--- a/app/archive_utils.py
+++ b/app/archive_utils.py
@@ -283,10 +283,15 @@ def append_weekly_archive(
     existing_keys = _existing_archive_keys(archive_path)
     rows_written = 0
     skipped = 0
-    archive_file = None
-    writer = None
 
-    try:
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    needs_header = not archive_path.exists() or archive_path.stat().st_size == 0
+
+    with archive_path.open("a", encoding="utf-8", newline="") as archive_file:
+        writer = csv.writer(archive_file)
+        if needs_header:
+            writer.writerow(ARCHIVE_HEADERS)
+
         for ticket in tickets:
             row = ticket_archive_row(ticket)
             key = _row_dedupe_key(row)
@@ -295,22 +300,8 @@ def append_weekly_archive(
                 continue
 
             existing_keys.add(key)
-
-            if writer is None:
-                archive_path.parent.mkdir(parents=True, exist_ok=True)
-                needs_header = (
-                    not archive_path.exists() or archive_path.stat().st_size == 0
-                )
-                archive_file = archive_path.open("a", encoding="utf-8", newline="")
-                writer = csv.writer(archive_file)
-                if needs_header:
-                    writer.writerow(ARCHIVE_HEADERS)
-
             writer.writerow(row)
             rows_written += 1
-    finally:
-        if archive_file is not None:
-            archive_file.close()
 
     return ArchiveWriteResult(
         path=archive_path,

--- a/app/archive_utils.py
+++ b/app/archive_utils.py
@@ -12,9 +12,9 @@ from typing import Iterable, Optional
 import click
 from flask import Flask
 from sqlalchemy import and_, func, or_
+from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.elements import ColumnElement
 
-from app import db
 from app.models import Ticket
 from app.time_utils import PACIFIC_TZ, ensure_aware_utc
 
@@ -100,19 +100,23 @@ def archive_ticket_query(
             Ticket.created_at < normalized_end,
         )
 
-    return Ticket.query.filter(
-        or_(
-            and_(
-                Ticket.status.in_(["closed", "resolved"]),
-                closed_range,
-            ),
-            and_(
-                Ticket.status == "resolved",
-                Ticket.closed_at.is_(None),
-                created_range,
-            ),
+    return (
+        Ticket.query.options(selectinload(Ticket.wormhole_assistant))
+        .filter(
+            or_(
+                and_(
+                    Ticket.status.in_(["closed", "resolved"]),
+                    closed_range,
+                ),
+                and_(
+                    Ticket.status == "resolved",
+                    Ticket.closed_at.is_(None),
+                    created_range,
+                ),
+            )
         )
-    ).order_by(func.coalesce(Ticket.closed_at, Ticket.created_at).desc())
+        .order_by(func.coalesce(Ticket.closed_at, Ticket.created_at).desc())
+    )
 
 
 def ticket_archive_row(ticket: Ticket) -> list[object]:
@@ -122,7 +126,7 @@ def ticket_archive_row(ticket: Ticket) -> list[object]:
         sanitize_csv_value(ticket.student_name),
         sanitize_csv_value(ticket.table),
         sanitize_csv_value(ticket.physics_course),
-        ticket.closed_reason,
+        ticket.status,
         ticket.created_at.strftime("%Y-%m-%d %H:%M:%S"),
         ticket.closed_at.strftime("%Y-%m-%d %H:%M:%S") if ticket.closed_at else "N/A",
         ticket.number_of_students,
@@ -153,17 +157,20 @@ def render_archive_csv(tickets: Iterable[Ticket]) -> str:
 def write_archive_file(path: Path, tickets: Iterable[Ticket]) -> ArchiveWriteResult:
     """Write a standalone archive CSV, replacing any existing file."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    ticket_list = list(tickets)
-    csv_content = render_archive_csv(ticket_list)
+    rows_written = 0
 
     with path.open("w", encoding="utf-8", newline="") as archive_file:
-        archive_file.write(csv_content)
+        writer = csv.writer(archive_file)
+        writer.writerow(ARCHIVE_HEADERS)
+        for ticket in tickets:
+            writer.writerow(ticket_archive_row(ticket))
+            rows_written += 1
 
     # start/end are not meaningful for this low-level helper; callers that need
     # those values should use create_archive_file or append_weekly_archive.
     return ArchiveWriteResult(
         path=path,
-        rows_written=len(ticket_list),
+        rows_written=rows_written,
         rows_skipped=0,
         start_utc=datetime.min.replace(tzinfo=timezone.utc),
         end_utc=datetime.min.replace(tzinfo=timezone.utc),
@@ -179,13 +186,12 @@ def create_archive_file(
 ) -> ArchiveWriteResult:
     """Create or replace a manual archive file for an explicit date range."""
     tickets = archive_ticket_query(start_utc, end_utc, include_end=True).yield_per(1000)
-    ticket_list = list(tickets)
     path = archive_dir(root_path) / filename
-    write_archive_file(path, ticket_list)
+    write_result = write_archive_file(path, tickets)
     return ArchiveWriteResult(
         path=path,
-        rows_written=len(ticket_list),
-        rows_skipped=0,
+        rows_written=write_result.rows_written,
+        rows_skipped=write_result.rows_skipped,
         start_utc=start_utc,
         end_utc=end_utc,
     )
@@ -339,7 +345,6 @@ def register_archive_cli(app: Flask) -> None:
             now=_parse_iso_datetime(now_value),
             filename=filename,
         )
-        db.session.commit()
 
         click.echo(
             "Weekly archive complete: "

--- a/app/archive_utils.py
+++ b/app/archive_utils.py
@@ -88,24 +88,23 @@ def archive_ticket_query(
         created_range = Ticket.created_at.between(start_utc, end_utc)
     else:
         closed_range = and_(Ticket.closed_at >= start_utc, Ticket.closed_at < end_utc)
-        created_range = and_(Ticket.created_at >= start_utc, Ticket.created_at < end_utc)
-
-    return (
-        Ticket.query.filter(
-            or_(
-                and_(
-                    Ticket.status.in_(["closed", "resolved"]),
-                    closed_range,
-                ),
-                and_(
-                    Ticket.status == "resolved",
-                    Ticket.closed_at.is_(None),
-                    created_range,
-                ),
-            )
+        created_range = and_(
+            Ticket.created_at >= start_utc, Ticket.created_at < end_utc
         )
-        .order_by(func.coalesce(Ticket.closed_at, Ticket.created_at).desc())
-    )
+
+    return Ticket.query.filter(
+        or_(
+            and_(
+                Ticket.status.in_(["closed", "resolved"]),
+                closed_range,
+            ),
+            and_(
+                Ticket.status == "resolved",
+                Ticket.closed_at.is_(None),
+                created_range,
+            ),
+        )
+    ).order_by(func.coalesce(Ticket.closed_at, Ticket.created_at).desc())
 
 
 def ticket_archive_row(ticket: Ticket) -> list[object]:
@@ -207,12 +206,18 @@ def _existing_archive_keys(path: Path) -> set[tuple[str, str, str]]:
             ticket_id = row.get("Ticket ID")
             created_at = row.get("Created At")
             closed_at = row.get("Closed At")
-            if ticket_id is not None and created_at is not None and closed_at is not None:
+            if (
+                ticket_id is not None
+                and created_at is not None
+                and closed_at is not None
+            ):
                 keys.add((ticket_id, created_at, closed_at))
     return keys
 
 
-def previous_saturday_week_bounds(now: Optional[datetime] = None) -> tuple[datetime, datetime]:
+def previous_saturday_week_bounds(
+    now: Optional[datetime] = None,
+) -> tuple[datetime, datetime]:
     """
     Return the previous completed Saturday-to-Saturday week in UTC.
 
@@ -245,7 +250,9 @@ def append_weekly_archive(
     """Append the latest completed week of tickets to the cumulative archive CSV."""
     start_utc, end_utc = previous_saturday_week_bounds(now)
     archive_path = archive_dir(root_path) / filename
-    tickets = archive_ticket_query(start_utc, end_utc, include_end=False).yield_per(1000)
+    tickets = archive_ticket_query(start_utc, end_utc, include_end=False).yield_per(
+        1000
+    )
 
     existing_keys = _existing_archive_keys(archive_path)
     rows: list[list[object]] = []

--- a/app/archive_utils.py
+++ b/app/archive_utils.py
@@ -35,6 +35,16 @@ ARCHIVE_HEADERS = [
 CUMULATIVE_ARCHIVE_FILENAME = "wormhole_archive_all.csv"
 
 
+def safe_archive_filename(filename: str) -> str:
+    """Return a safe CSV filename for files stored in the archive directory."""
+    safe_name = Path(filename).name.strip()
+    if not safe_name:
+        safe_name = CUMULATIVE_ARCHIVE_FILENAME
+    if Path(safe_name).suffix.lower() != ".csv":
+        safe_name = f"{safe_name}.csv"
+    return safe_name
+
+
 @dataclass(frozen=True)
 class ArchiveWriteResult:
     """Summary of one archive write operation."""
@@ -131,9 +141,11 @@ def ticket_archive_row(ticket: Ticket) -> list[object]:
         ticket.closed_at.strftime("%Y-%m-%d %H:%M:%S") if ticket.closed_at else "N/A",
         ticket.number_of_students,
         ticket.wa_id or "Unassigned",
-        ticket.wormhole_assistant.name
-        if ticket.wormhole_assistant and ticket.wormhole_assistant.name
-        else "N/A",
+        sanitize_csv_value(
+            ticket.wormhole_assistant.name
+            if ticket.wormhole_assistant and ticket.wormhole_assistant.name
+            else "N/A"
+        ),
         "Zoom"
         if ticket.table == "Zoom"
         else "Teams"
@@ -186,7 +198,7 @@ def create_archive_file(
 ) -> ArchiveWriteResult:
     """Create or replace a manual archive file for an explicit date range."""
     tickets = archive_ticket_query(start_utc, end_utc, include_end=True).yield_per(1000)
-    path = archive_dir(root_path) / filename
+    path = archive_dir(root_path) / safe_archive_filename(filename)
     write_result = write_archive_file(path, tickets)
     return ArchiveWriteResult(
         path=path,
@@ -263,7 +275,7 @@ def append_weekly_archive(
 ) -> ArchiveWriteResult:
     """Append the latest completed week of tickets to the cumulative archive CSV."""
     start_utc, end_utc = previous_saturday_week_bounds(now)
-    archive_path = archive_dir(root_path) / filename
+    archive_path = archive_dir(root_path) / safe_archive_filename(filename)
     tickets = archive_ticket_query(start_utc, end_utc, include_end=False).yield_per(
         1000
     )

--- a/app/archive_utils.py
+++ b/app/archive_utils.py
@@ -1,0 +1,334 @@
+"""Helpers and CLI commands for ticket archive CSV generation."""
+
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass
+from datetime import datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+import click
+from flask import Flask
+from sqlalchemy import and_, func, or_
+
+from app import db
+from app.models import Ticket
+from app.time_utils import PACIFIC_TZ, ensure_aware_utc
+
+ARCHIVE_HEADERS = [
+    "Ticket ID",
+    "Student Name",
+    "Table",
+    "Course",
+    "Status",
+    "Created At",
+    "Closed At",
+    "Students Helped",
+    "Assistant ID",
+    "Assistant Name",
+    "Ticket Type",
+]
+
+CUMULATIVE_ARCHIVE_FILENAME = "wormhole_archive_all.csv"
+
+
+@dataclass(frozen=True)
+class ArchiveWriteResult:
+    """Summary of one archive write operation."""
+
+    path: Path
+    rows_written: int
+    rows_skipped: int
+    start_utc: datetime
+    end_utc: datetime
+
+
+def archive_dir(root_path: str | Path) -> Path:
+    """Return the app archive directory, creating it when needed."""
+    archive_path = Path(root_path) / "data" / "archives"
+    archive_path.mkdir(parents=True, exist_ok=True)
+    return archive_path
+
+
+def list_archive_files(root_path: str | Path) -> list[str]:
+    """List saved CSV archive files newest-first by filename."""
+    return sorted(
+        [path.name for path in archive_dir(root_path).glob("*.csv") if path.is_file()],
+        reverse=True,
+    )
+
+
+def sanitize_csv_value(value):
+    """Prevent spreadsheet formula execution when archive CSVs are opened."""
+    if value and isinstance(value, str):
+        normalized = value.lstrip()
+        if normalized.startswith(("=", "+", "-", "@")):
+            # Prepend quote to the ORIGINAL value so leading whitespace is preserved.
+            return f"'{value}"
+    return value
+
+
+def archive_ticket_query(
+    start_utc: datetime,
+    end_utc: datetime,
+    *,
+    include_end: bool = True,
+):
+    """Build the ticket query used by manual and weekly archive exports."""
+    start_utc = ensure_aware_utc(start_utc)
+    end_utc = ensure_aware_utc(end_utc)
+
+    if start_utc is None or end_utc is None:
+        raise ValueError("start_utc and end_utc are required")
+
+    if include_end:
+        closed_range = Ticket.closed_at.between(start_utc, end_utc)
+        created_range = Ticket.created_at.between(start_utc, end_utc)
+    else:
+        closed_range = and_(Ticket.closed_at >= start_utc, Ticket.closed_at < end_utc)
+        created_range = and_(Ticket.created_at >= start_utc, Ticket.created_at < end_utc)
+
+    return (
+        Ticket.query.filter(
+            or_(
+                and_(
+                    Ticket.status.in_(["closed", "resolved"]),
+                    closed_range,
+                ),
+                and_(
+                    Ticket.status == "resolved",
+                    Ticket.closed_at.is_(None),
+                    created_range,
+                ),
+            )
+        )
+        .order_by(func.coalesce(Ticket.closed_at, Ticket.created_at).desc())
+    )
+
+
+def ticket_archive_row(ticket: Ticket) -> list[object]:
+    """Convert one ticket to the shared CSV row format."""
+    return [
+        ticket.id,
+        sanitize_csv_value(ticket.student_name),
+        sanitize_csv_value(ticket.table),
+        sanitize_csv_value(ticket.physics_course),
+        ticket.closed_reason,
+        ticket.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+        ticket.closed_at.strftime("%Y-%m-%d %H:%M:%S") if ticket.closed_at else "N/A",
+        ticket.number_of_students,
+        ticket.wa_id or "Unassigned",
+        ticket.wormhole_assistant.name
+        if ticket.wormhole_assistant and ticket.wormhole_assistant.name
+        else "N/A",
+        "Zoom"
+        if ticket.table == "Zoom"
+        else "Teams"
+        if ticket.table == "Teams"
+        else "Box",
+    ]
+
+
+def render_archive_csv(tickets: Iterable[Ticket]) -> str:
+    """Render tickets as a complete CSV document with one header row."""
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(ARCHIVE_HEADERS)
+
+    for ticket in tickets:
+        writer.writerow(ticket_archive_row(ticket))
+
+    return output.getvalue()
+
+
+def write_archive_file(path: Path, tickets: Iterable[Ticket]) -> ArchiveWriteResult:
+    """Write a standalone archive CSV, replacing any existing file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ticket_list = list(tickets)
+    csv_content = render_archive_csv(ticket_list)
+
+    with path.open("w", encoding="utf-8", newline="") as archive_file:
+        archive_file.write(csv_content)
+
+    # start/end are not meaningful for this low-level helper; callers that need
+    # those values should use create_archive_file or append_weekly_archive.
+    return ArchiveWriteResult(
+        path=path,
+        rows_written=len(ticket_list),
+        rows_skipped=0,
+        start_utc=datetime.min.replace(tzinfo=timezone.utc),
+        end_utc=datetime.min.replace(tzinfo=timezone.utc),
+    )
+
+
+def create_archive_file(
+    *,
+    root_path: str | Path,
+    start_utc: datetime,
+    end_utc: datetime,
+    filename: str,
+) -> ArchiveWriteResult:
+    """Create or replace a manual archive file for an explicit date range."""
+    tickets = archive_ticket_query(start_utc, end_utc, include_end=True).yield_per(1000)
+    ticket_list = list(tickets)
+    path = archive_dir(root_path) / filename
+    write_archive_file(path, ticket_list)
+    return ArchiveWriteResult(
+        path=path,
+        rows_written=len(ticket_list),
+        rows_skipped=0,
+        start_utc=start_utc,
+        end_utc=end_utc,
+    )
+
+
+def _row_dedupe_key(row: list[object]) -> tuple[str, str, str]:
+    """
+    Build a stable key for duplicate prevention in cumulative archives.
+
+    The queue can reset ticket IDs after an admin clears data, so ID alone is not
+    safe. Combining ID with created/closed timestamps keeps the weekly append
+    command idempotent without blocking newly-created tickets that reuse an old ID.
+    """
+    return (str(row[0]), str(row[5]), str(row[6]))
+
+
+def _existing_archive_keys(path: Path) -> set[tuple[str, str, str]]:
+    """Read existing cumulative archive rows so repeat jobs do not duplicate rows."""
+    if not path.exists() or path.stat().st_size == 0:
+        return set()
+
+    keys: set[tuple[str, str, str]] = set()
+    with path.open("r", encoding="utf-8", newline="") as archive_file:
+        reader = csv.DictReader(archive_file)
+        for row in reader:
+            ticket_id = row.get("Ticket ID")
+            created_at = row.get("Created At")
+            closed_at = row.get("Closed At")
+            if ticket_id is not None and created_at is not None and closed_at is not None:
+                keys.add((ticket_id, created_at, closed_at))
+    return keys
+
+
+def previous_saturday_week_bounds(now: Optional[datetime] = None) -> tuple[datetime, datetime]:
+    """
+    Return the previous completed Saturday-to-Saturday week in UTC.
+
+    The intended production schedule is Saturday at 00:00 Pacific. This helper is
+    also safe if an admin manually runs the command later; it archives the most
+    recent completed week ending at the latest Saturday midnight Pacific.
+    """
+    if now is None:
+        now_local = datetime.now(PACIFIC_TZ)
+    else:
+        aware_now = ensure_aware_utc(now)
+        if aware_now is None:
+            raise ValueError("now cannot be None")
+        now_local = aware_now.astimezone(PACIFIC_TZ)
+
+    days_since_saturday = (now_local.weekday() - 5) % 7
+    end_date = now_local.date() - timedelta(days=days_since_saturday)
+    end_local = datetime.combine(end_date, time.min, tzinfo=PACIFIC_TZ)
+    start_local = end_local - timedelta(days=7)
+
+    return start_local.astimezone(timezone.utc), end_local.astimezone(timezone.utc)
+
+
+def append_weekly_archive(
+    *,
+    root_path: str | Path,
+    now: Optional[datetime] = None,
+    filename: str = CUMULATIVE_ARCHIVE_FILENAME,
+) -> ArchiveWriteResult:
+    """Append the latest completed week of tickets to the cumulative archive CSV."""
+    start_utc, end_utc = previous_saturday_week_bounds(now)
+    archive_path = archive_dir(root_path) / filename
+    tickets = archive_ticket_query(start_utc, end_utc, include_end=False).yield_per(1000)
+
+    existing_keys = _existing_archive_keys(archive_path)
+    rows: list[list[object]] = []
+    skipped = 0
+
+    for ticket in tickets:
+        row = ticket_archive_row(ticket)
+        key = _row_dedupe_key(row)
+        if key in existing_keys:
+            skipped += 1
+            continue
+        existing_keys.add(key)
+        rows.append(row)
+
+    if not rows:
+        return ArchiveWriteResult(
+            path=archive_path,
+            rows_written=0,
+            rows_skipped=skipped,
+            start_utc=start_utc,
+            end_utc=end_utc,
+        )
+
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    needs_header = not archive_path.exists() or archive_path.stat().st_size == 0
+
+    with archive_path.open("a", encoding="utf-8", newline="") as archive_file:
+        writer = csv.writer(archive_file)
+        if needs_header:
+            writer.writerow(ARCHIVE_HEADERS)
+        writer.writerows(rows)
+
+    return ArchiveWriteResult(
+        path=archive_path,
+        rows_written=len(rows),
+        rows_skipped=skipped,
+        start_utc=start_utc,
+        end_utc=end_utc,
+    )
+
+
+def _parse_iso_datetime(value: Optional[str]) -> Optional[datetime]:
+    """Parse an optional ISO datetime for deterministic CLI/testing use."""
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=PACIFIC_TZ)
+    return parsed
+
+
+def register_archive_cli(app: Flask) -> None:
+    """Register archive maintenance commands on the Flask app."""
+
+    @app.cli.command("archive-weekly")
+    @click.option(
+        "--now",
+        "now_value",
+        help="Optional ISO datetime used as the current time, mainly for testing.",
+    )
+    @click.option(
+        "--filename",
+        default=CUMULATIVE_ARCHIVE_FILENAME,
+        show_default=True,
+        help="Cumulative archive filename inside app/data/archives.",
+    )
+    def archive_weekly_command(now_value: Optional[str], filename: str) -> None:
+        """Append the latest completed Saturday-to-Saturday archive week."""
+        result = append_weekly_archive(
+            root_path=app.root_path,
+            now=_parse_iso_datetime(now_value),
+            filename=filename,
+        )
+        db.session.commit()
+
+        click.echo(
+            "Weekly archive complete: "
+            f"{result.rows_written} row(s) appended, "
+            f"{result.rows_skipped} duplicate row(s) skipped, "
+            f"file={result.path.name}"
+        )

--- a/app/archive_utils.py
+++ b/app/archive_utils.py
@@ -12,6 +12,7 @@ from typing import Iterable, Optional
 import click
 from flask import Flask
 from sqlalchemy import and_, func, or_
+from sqlalchemy.sql.elements import ColumnElement
 
 from app import db
 from app.models import Ticket
@@ -77,19 +78,26 @@ def archive_ticket_query(
     include_end: bool = True,
 ):
     """Build the ticket query used by manual and weekly archive exports."""
-    start_utc = ensure_aware_utc(start_utc)
-    end_utc = ensure_aware_utc(end_utc)
+    normalized_start = ensure_aware_utc(start_utc)
+    normalized_end = ensure_aware_utc(end_utc)
 
-    if start_utc is None or end_utc is None:
+    if normalized_start is None or normalized_end is None:
         raise ValueError("start_utc and end_utc are required")
 
+    closed_range: ColumnElement[bool]
+    created_range: ColumnElement[bool]
+
     if include_end:
-        closed_range = Ticket.closed_at.between(start_utc, end_utc)
-        created_range = Ticket.created_at.between(start_utc, end_utc)
+        closed_range = Ticket.closed_at.between(normalized_start, normalized_end)
+        created_range = Ticket.created_at.between(normalized_start, normalized_end)
     else:
-        closed_range = and_(Ticket.closed_at >= start_utc, Ticket.closed_at < end_utc)
+        closed_range = and_(
+            Ticket.closed_at >= normalized_start,
+            Ticket.closed_at < normalized_end,
+        )
         created_range = and_(
-            Ticket.created_at >= start_utc, Ticket.created_at < end_utc
+            Ticket.created_at >= normalized_start,
+            Ticket.created_at < normalized_end,
         )
 
     return Ticket.query.filter(

--- a/app/routes/views.py
+++ b/app/routes/views.py
@@ -23,6 +23,8 @@ from sqlalchemy import text
 from app import db
 from app.archive_utils import (
     archive_dir as get_archive_dir,
+)
+from app.archive_utils import (
     archive_ticket_query,
     create_archive_file,
     list_archive_files,

--- a/app/routes/views.py
+++ b/app/routes/views.py
@@ -1,6 +1,4 @@
 # app/routes/views.py
-import csv
-import io
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -9,6 +7,7 @@ from urllib.parse import urljoin, urlparse
 from flask import (
     Blueprint,
     abort,
+    current_app,
     flash,
     redirect,
     render_template,
@@ -19,9 +18,15 @@ from flask import (
 )
 
 # Explicit imports for SQLAlchemy operators to ensure compatibility
-from sqlalchemy import and_, func, or_, text
+from sqlalchemy import text
 
 from app import db
+from app.archive_utils import (
+    archive_dir as get_archive_dir,
+    archive_ticket_query,
+    create_archive_file,
+    list_archive_files,
+)
 from app.auth_utils import admin_required, login_required
 from app.forms import (
     ChangePassForm,
@@ -92,20 +97,6 @@ def _ticket_to_ns(ticket: Ticket):
         closed_reason=ticket.closed_reason,
         closed_by=assistant_display_name,
         assigned_to=assistant_display_name,
-    )
-
-
-def _archive_dir() -> Path:
-    archive_dir = Path(__file__).resolve().parents[1] / "data" / "archives"
-    archive_dir.mkdir(parents=True, exist_ok=True)
-    return archive_dir
-
-
-def _list_archive_files() -> list[str]:
-    archive_dir = _archive_dir()
-    return sorted(
-        [path.name for path in archive_dir.glob("*.csv") if path.is_file()],
-        reverse=True,
     )
 
 
@@ -387,88 +378,24 @@ def export_archive():
         flash("Dates cannot be in the future.", "error")
         return redirect(url_for("views.archive"))
 
-    # Query the database using closed_at OR fallback to created_at for resolved tickets
-    # Using explicit or_ / and_ for compatibility
-    tickets_query = Ticket.query.filter(
-        or_(
-            and_(
-                Ticket.status.in_(["closed", "resolved"]),
-                Ticket.closed_at.between(start_date, end_date),
-            ),
-            and_(
-                Ticket.status == "resolved",
-                Ticket.closed_at.is_(None),
-                Ticket.created_at.between(start_date, end_date),
-            ),
-        )
-    ).order_by(func.coalesce(Ticket.closed_at, Ticket.created_at).desc())
+    tickets_query = archive_ticket_query(start_date, end_date, include_end=True)
 
     # Optimization: Use limit(1) instead of count() to check for existence
     if tickets_query.limit(1).first() is None:
         flash("No closed or resolved tickets found for this period.", "info")
         return redirect(url_for("views.archive"))
 
-    output = io.StringIO()
-    writer = csv.writer(output)
-
-    # CSV Injection Sanitization Helper
-    def sanitize(value):
-        if value and isinstance(value, str):
-            normalized = value.lstrip()
-            if normalized.startswith(("=", "+", "-", "@")):
-                # Prepend quote to the ORIGINAL value so leading whitespace is preserved
-                return f"'{value}"
-        return value
-
-    writer.writerow(
-        [
-            "Ticket ID",
-            "Student Name",
-            "Table",
-            "Course",
-            "Status",
-            "Created At",
-            "Closed At",
-            "Students Helped",
-            "Assistant ID",
-            "Assistant Name",
-            "Ticket Type",
-        ]
-    )
-
-    for t in tickets_query.yield_per(1000):
-        writer.writerow(
-            [
-                t.id,
-                sanitize(t.student_name),
-                sanitize(t.table),
-                sanitize(t.physics_course),
-                t.closed_reason,
-                t.created_at.strftime("%Y-%m-%d %H:%M:%S"),
-                t.closed_at.strftime("%Y-%m-%d %H:%M:%S") if t.closed_at else "N/A",
-                t.number_of_students,
-                t.wa_id or "Unassigned",
-                t.wormhole_assistant.name
-                if t.wormhole_assistant and t.wormhole_assistant.name
-                else ("N/A"),
-                "Zoom"
-                if t.table == "Zoom"
-                else "Teams"
-                if t.table == "Teams"
-                else "Box",
-            ]
-        )
-
-    csv_content = output.getvalue()
-
     safe_start = start_date.date().isoformat()
     safe_end = end_date.date().isoformat()
     filename = f"wormhole_archive_{safe_start}_to_{safe_end}.csv"
 
-    archive_path = _archive_dir() / filename
     try:
-        with archive_path.open("w", encoding="utf-8", newline="") as archive_file:
-            archive_file.write(csv_content)
+        create_archive_file(
+            root_path=current_app.root_path,
+            start_utc=start_date,
+            end_utc=end_date,
+            filename=filename,
+        )
     except OSError:
         flash("Failed to save archive file on server.", "error")
         return redirect(url_for("views.archive"))
@@ -486,7 +413,7 @@ def archive():
     # Instantiate form for the template to render CSRF token and fields
     form = ExportArchiveForm()
     delete_form = DeleteArchiveForm()
-    archive_files = _list_archive_files()
+    archive_files = list_archive_files(current_app.root_path)
     tkt_list = []
     assoc_list = []
     return render_template(
@@ -512,7 +439,7 @@ def delete_archives():
         flash("No archive files selected.", "info")
         return redirect(url_for("views.archive"))
 
-    archive_dir = _archive_dir()
+    archive_dir_path = get_archive_dir(current_app.root_path)
     deleted_count = 0
 
     for raw_name in selected_files:
@@ -520,7 +447,7 @@ def delete_archives():
         if safe_name != raw_name or not safe_name.lower().endswith(".csv"):
             continue
 
-        archive_path = archive_dir / safe_name
+        archive_path = archive_dir_path / safe_name
         try:
             if archive_path.is_file():
                 archive_path.unlink()
@@ -543,12 +470,12 @@ def download_archive(filename):
     if safe_filename != filename or not safe_filename.lower().endswith(".csv"):
         abort(404)
 
-    archive_dir = _archive_dir()
-    file_path = archive_dir / safe_filename
+    archive_dir_path = get_archive_dir(current_app.root_path)
+    file_path = archive_dir_path / safe_filename
     if not file_path.is_file():
         abort(404)
 
-    return send_from_directory(str(archive_dir), safe_filename, as_attachment=True)
+    return send_from_directory(str(archive_dir_path), safe_filename, as_attachment=True)
 
 
 @views_bp.route("/user/<username>")

--- a/app/templates/archive.html
+++ b/app/templates/archive.html
@@ -11,7 +11,7 @@
             <h3>
                 Export Configuration
             </h3>
-            <form action="{{ url_for("views.export_archive") }}" method="post">
+            <form action="{{ url_for('views.export_archive') }}" method="post">
                 {{ form.hidden_tag() }}
                 <div style="margin-bottom: 1rem;">
                     {{ form.start_date.label() }}
@@ -35,7 +35,9 @@
             </form>
         </div>
         <div class="section generic">
-            <h2>Archive Files</h2>
+            <h2>
+                Archive Files
+            </h2>
             <p>
                 Below is a list of previously exported archive files. Click on a file name to download it.
             </p>
@@ -50,11 +52,15 @@
                             </label>
                         </li>
                     {% else %}
-                        <li>No archive files found.</li>
+                        <li>
+                            No archive files found.
+                        </li>
                     {% endfor %}
                 </ul>
                 <div style="margin-top: 1rem;">
-                    <button type="submit" class="btn-danger">Delete Selected</button>
+                    <button type="submit" class="btn-danger">
+                        Delete Selected
+                    </button>
                 </div>
             </form>
         </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -27,28 +27,28 @@
                     Oregon State University Wormhole
                 </h1>
                 <div class="navbar">
-                    <a href="{{ url_for("views.index") }}">Home</a>
-                    <a href="{{ url_for("views.create_ticket_page") }}">Submit Request</a>
-                    <a href="{{ url_for("views.livequeue") }}">Live Queue</a>
-                    <a href="{{ url_for("views.wiki") }}">Wiki</a>
+                    <a href="{{ url_for('views.index') }}">Home</a>
+                    <a href="{{ url_for('views.create_ticket_page') }}">Submit Request</a>
+                    <a href="{{ url_for('views.livequeue') }}">Live Queue</a>
+                    <a href="{{ url_for('views.wiki') }}">Wiki</a>
                     <div class="dropdown">
                         <button class="dropbtn">
                             User
                         </button>
                         <div class="dropdown-content">
                             {% if current_user.is_anonymous %}
-                                <a href="{{ url_for("views.assistant_login") }}">Log In</a>
+                                <a href="{{ url_for('views.assistant_login') }}">Log In</a>
                             {% else %}
                                 <a href="{{ url_for('views.userpage', username=current_user.username) }}">Profile</a>
                                 {% if current_user.is_admin %}
                                     <div class = "admin-links">
-                                        <a href="{{ url_for("views.register") }}">Register New User</a>
-                                        <a href="{{ url_for("views.queue") }}">Queue</a>
-                                        <a href="{{ url_for("views.archive") }}">Archive</a>
+                                        <a href="{{ url_for('views.register') }}">Register New User</a>
+                                        <a href="{{ url_for('views.queue') }}">Queue</a>
+                                        <a href="{{ url_for('views.archive') }}">Archive</a>
                                     </div>
                                 {% endif %}
-                                <a href="{{ url_for("views.hardware_list") }}">Hardware List</a>
-                                <a href="{{ url_for("views.logout") }}">Log Out</a>
+                                <a href="{{ url_for('views.hardware_list') }}">Hardware List</a>
+                                <a href="{{ url_for('views.logout') }}">Log Out</a>
                             {% endif %}
                         </div>
                     </div>

--- a/app/templates/currentticket.html
+++ b/app/templates/currentticket.html
@@ -65,8 +65,16 @@
                 <button type="submit" name="resolve" value="return_to_queue">
                     Return To Queue
                 </button>
-                <label for="numstudents">Number of Students:</label>
-                <input type="number" id="numstudents" name="numstudents" min="0" max="100" step="1" value="1">
+                <label for="numstudents">
+                    Number of Students:
+                </label>
+                <input type="number"
+                       id="numstudents"
+                       name="numstudents"
+                       min="0"
+                       max="100"
+                       step="1"
+                       value="1">
             </form>
         </div>
     </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,7 +10,7 @@
                 For Students
             </h2>
             <p class="index-section-link">
-                <a href="{{ url_for("views.create_ticket_page") }}">Submit a Help Request</a>
+                <a href="{{ url_for('views.create_ticket_page') }}">Submit a Help Request</a>
             </p>
             <p class="index-section-link">
                 <a href="https://oregonstate.zoom.us/j/95601298258">Join Zoom Meeting</a>
@@ -29,7 +29,7 @@
             </h2>
             {% if current_user.is_anonymous %}
                 <p class="index-section-link">
-                    <a href="{{ url_for("views.assistant_login") }}">Log In</a>
+                    <a href="{{ url_for('views.assistant_login') }}">Log In</a>
                 </p>
             {% else %}
                 <p class="index-section-link">
@@ -79,7 +79,7 @@
                 </p>
                 <p>
                     If you or your group needs help with a physics question, send a request to the queue.
-                    In person, use the box on your table. Online, use this <a href="{{ url_for("views.create_ticket_page") }}">link</a>.
+                    In person, use the box on your table. Online, use this <a href="{{ url_for('views.create_ticket_page') }}">link</a>.
                     Only one person in the group needs to enter the request, and only one time for each
                     question, please. You can see your place in the help queue using the Live Queue link at
                     the top of the page. Multiple requests for a question won’t get you help any faster, and

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -31,7 +31,7 @@
                     {{ form.submit() }}
                 </p>
                 <p style="text-align:center">
-                    <a href="{{ url_for("auth.reset_password_request") }}">Reset Password</a>
+                    <a href="{{ url_for('auth.reset_password_request') }}">Reset Password</a>
                 </p>
             </form>
         </div>

--- a/app/templates/pastticket.html
+++ b/app/templates/pastticket.html
@@ -44,7 +44,7 @@
                 </button>
             </form>
             <div style="margin-top: 20px;">
-                <a href="{{ url_for("views.queue") }}">Back to Queue</a>
+                <a href="{{ url_for('views.queue') }}">Back to Queue</a>
             </div>
         </div>
     </div>

--- a/app/templates/queue.html
+++ b/app/templates/queue.html
@@ -11,7 +11,7 @@
             </h2>
             {% if user.is_admin %}
                 <div class="queue-admin-actions">
-                    <form action="{{ url_for("views.flush") }}"
+                    <form action="{{ url_for('views.flush') }}"
                           method="post"
                           class="queue-admin-action-form">
                         {{ flush_form.hidden_tag() }}
@@ -21,7 +21,7 @@
                             Flush Queue
                         </button>
                     </form>
-                    <form action="{{ url_for("views.clear_queue") }}"
+                    <form action="{{ url_for('views.clear_queue') }}"
                           method="post"
                           class="queue-admin-action-form">
                         {{ clear_form.hidden_tag() }}
@@ -76,7 +76,7 @@
                 </ul>
             </div>
             <div class="queue-back-link">
-                <a href="{{ url_for("views.hardware_list") }}">Back to Hardware List</a>
+                <a href="{{ url_for('views.hardware_list') }}">Back to Hardware List</a>
             </div>
         </div>
     </div>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -5,7 +5,7 @@
             <h1>
                 New User Registration
             </h1>
-            <form action="{{ url_for("users.users_add") }}" method="post" novalidate>
+            <form action="{{ url_for('users.users_add') }}" method="post" novalidate>
                 {{ form.hidden_tag() }}
                 <p>
                     {{ form.first_name.label }}

--- a/app/templates/userpage.html
+++ b/app/templates/userpage.html
@@ -53,7 +53,7 @@
                 <b>Administrator: </b>{{ user.is_admin }}
                 <br>
                 {% if current_user.username==user.username or current_user.is_admin %}
-                    <a href="{{ url_for("views.changepass") }}">Change Password</a>
+                    <a href="{{ url_for('views.changepass') }}">Change Password</a>
                 {% endif %}
             </p>
             {% if current_user.is_admin %}
@@ -61,20 +61,20 @@
                     Admin Utilities
                 </h3>
                 <p style="margin:10px">
-                    <a href="{{ url_for("views.register") }}">Register New User</a>
+                    <a href="{{ url_for('views.register') }}">Register New User</a>
                 </p>
                 <!--<p><a href="{{ url_for('views.changepass') }}">Change User Password</a></p>-->
                 <p style="margin:10px">
-                    <a href="{{ url_for("views.queue") }}">Queue</a>
+                    <a href="{{ url_for('views.queue') }}">Queue</a>
                 </p>
                 <p style="margin:10px">
-                    <a href="{{ url_for("views.archive") }}">Archive</a>
+                    <a href="{{ url_for('views.archive') }}">Archive</a>
                 </p>
                 <p style="margin:10px">
-                    <a href="{{ url_for("views.register_batch") }}">Register Users in Batch</a>
+                    <a href="{{ url_for('views.register_batch') }}">Register Users in Batch</a>
                 </p>
                 <p style="margin:10px">
-                    <a href="{{ url_for("views.user_list") }}">WA List</a>
+                    <a href="{{ url_for('views.user_list') }}">WA List</a>
                 </p>
             {% endif %}
         </div>

--- a/deploy/DEPLOY_EC2_NGINX.md
+++ b/deploy/DEPLOY_EC2_NGINX.md
@@ -69,3 +69,27 @@ Do not expose 8000 publicly.
 - http://queue.example.com redirects to HTTPS
 - Login/session works
 - Live queue updates function (Socket.IO over WSS)
+
+## 7) Enable automatic weekly archives
+
+The app includes a Flask CLI command that appends the most recently completed Saturday-to-Saturday week to `app/data/archives/wormhole_archive_all.csv`:
+
+```bash
+source venv/bin/activate
+export FLASK_APP=application:application
+flask archive-weekly
+```
+
+To run this automatically every Saturday at midnight Pacific using systemd:
+
+1. Copy the timer and service files:
+   - `sudo cp deploy/systemd/wormhole-weekly-archive.service /etc/systemd/system/wormhole-weekly-archive.service`
+   - `sudo cp deploy/systemd/wormhole-weekly-archive.timer /etc/systemd/system/wormhole-weekly-archive.timer`
+2. Reload systemd and enable the timer:
+   - `sudo systemctl daemon-reload`
+   - `sudo systemctl enable --now wormhole-weekly-archive.timer`
+3. Verify the timer:
+   - `systemctl list-timers wormhole-weekly-archive.timer`
+   - `sudo journalctl -u wormhole-weekly-archive.service -n 50`
+
+The timer uses `Timezone=America/Los_Angeles`. If your systemd version does not support that setting, set the server timezone with `sudo timedatectl set-timezone America/Los_Angeles`, remove the `Timezone=` line, then reload systemd.

--- a/deploy/systemd/wormhole-weekly-archive.service
+++ b/deploy/systemd/wormhole-weekly-archive.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Append Wormhole weekly ticket archive
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=ec2-user
+Group=ec2-user
+WorkingDirectory=/home/ec2-user/CS461-wormhole-queue-system
+EnvironmentFile=/etc/wormhole/wormhole.env
+Environment=FLASK_APP=application:application
+ExecStart=/home/ec2-user/CS461-wormhole-queue-system/venv/bin/flask archive-weekly

--- a/deploy/systemd/wormhole-weekly-archive.timer
+++ b/deploy/systemd/wormhole-weekly-archive.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run Wormhole weekly ticket archive every Saturday at midnight Pacific
+
+[Timer]
+OnCalendar=Sat *-*-* 00:00:00
+Timezone=America/Los_Angeles
+Persistent=true
+Unit=wormhole-weekly-archive.service
+
+[Install]
+WantedBy=timers.target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,16 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.mypy]
-# Mypy configuration
 python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
+exclude = [
+    "^venv/",
+    "^\\.venv/",
+    "^migrations/",
+    "^node_modules/",
+    "^htmlcov/",
+    "^playwright-report/",
+    "^test-results/",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,4 @@ python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
-exclude = [
-    "^venv/",
-    "^\\.venv/",
-    "^migrations/",
-    "^node_modules/",
-    "^htmlcov/",
-    "^playwright-report/",
-    "^test-results/",
-]
+exclude = "^(venv/|\\.venv/|migrations/|node_modules/|htmlcov/|playwright-report/|test-results/)"

--- a/run.py
+++ b/run.py
@@ -1,4 +1,6 @@
 # run.py
+import os
+
 import sqlalchemy as sa
 from dotenv import load_dotenv
 from sqlalchemy import orm
@@ -7,6 +9,7 @@ from app import create_app, db, socketio
 from app.models import Skipped, Ticket, User
 
 result = load_dotenv("wormhole.env")
+os.environ.setdefault("ALLOW_SQLITE_FALLBACK", "1")
 
 
 app = create_app()

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,8 +1,20 @@
 module.exports = {
   extends: "stylelint-config-standard",
+  ignoreFiles: [
+    "venv/**",
+    ".venv/**",
+    "node_modules/**",
+    "htmlcov/**",
+    "coverage/**",
+    "playwright-report/**",
+    "test-results/**",
+    "tests/browser/test-results/**",
+    "app/static/vendor/**",
+    "app/static/**/*.min.css",
+  ],
   rules: {
     "no-duplicate-selectors": true,
     "color-no-invalid-hex": true,
-    "comment-empty-line-before": null
-  }
+    "comment-empty-line-before": null,
+  },
 };

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -1,10 +1,10 @@
 import csv
 from datetime import datetime, timezone
 from pathlib import Path
+from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 from app import db
-from app.archive_utils import CUMULATIVE_ARCHIVE_FILENAME
 from app.models import Ticket, User
 
 
@@ -67,37 +67,49 @@ def test_archive_weekly_cli_appends_previous_week_once(test_app):
     db.session.add_all([inside_week, before_week, next_week_boundary])
     db.session.commit()
 
-    archive_path = (
-        Path(test_app.root_path) / "data" / "archives" / CUMULATIVE_ARCHIVE_FILENAME
-    )
-    if archive_path.exists():
-        archive_path.unlink()
+    archive_filename = f"wormhole_archive_weekly_cli_{uuid4().hex}.csv"
+    archive_path = Path(test_app.root_path) / "data" / "archives" / archive_filename
 
     runner = test_app.test_cli_runner()
-    first_run = runner.invoke(
-        args=["archive-weekly", "--now", "2026-04-25T00:00:00-07:00"]
-    )
-    assert first_run.exit_code == 0
-    assert "1 row(s) appended" in first_run.output
-    assert archive_path.exists()
+    try:
+        first_run = runner.invoke(
+            args=[
+                "archive-weekly",
+                "--now",
+                "2026-04-25T00:00:00-07:00",
+                "--filename",
+                archive_filename,
+            ]
+        )
+        assert first_run.exit_code == 0
+        assert "1 row(s) appended" in first_run.output
+        assert archive_path.exists()
 
-    with archive_path.open("r", encoding="utf-8", newline="") as archive_file:
-        rows = list(csv.DictReader(archive_file))
+        with archive_path.open("r", encoding="utf-8", newline="") as archive_file:
+            rows = list(csv.DictReader(archive_file))
 
-    assert len(rows) == 1
-    assert rows[0]["Student Name"] == "Inside Week"
-    assert rows[0]["Assistant Name"] == "Weekly Helper"
+        assert len(rows) == 1
+        assert rows[0]["Student Name"] == "Inside Week"
+        assert rows[0]["Status"] == "closed"
+        assert rows[0]["Assistant Name"] == "Weekly Helper"
 
-    second_run = runner.invoke(
-        args=["archive-weekly", "--now", "2026-04-25T00:00:00-07:00"]
-    )
-    assert second_run.exit_code == 0
-    assert "0 row(s) appended" in second_run.output
-    assert "1 duplicate row(s) skipped" in second_run.output
+        second_run = runner.invoke(
+            args=[
+                "archive-weekly",
+                "--now",
+                "2026-04-25T00:00:00-07:00",
+                "--filename",
+                archive_filename,
+            ]
+        )
+        assert second_run.exit_code == 0
+        assert "0 row(s) appended" in second_run.output
+        assert "1 duplicate row(s) skipped" in second_run.output
 
-    with archive_path.open("r", encoding="utf-8", newline="") as archive_file:
-        rows = list(csv.DictReader(archive_file))
+        with archive_path.open("r", encoding="utf-8", newline="") as archive_file:
+            rows = list(csv.DictReader(archive_file))
 
-    assert len(rows) == 1
-
-    archive_path.unlink()
+        assert len(rows) == 1
+    finally:
+        if archive_path.exists():
+            archive_path.unlink()

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -137,7 +137,7 @@ def test_archive_weekly_cli_confines_filename_to_archive_directory(test_app):
 
     archive_dir = Path(test_app.root_path) / "data" / "archives"
     archive_path = archive_dir / "unsafe_name.csv"
-    escaped_path = archive_dir.parent / "unsafe_name"
+    escaped_path = archive_dir.parent / "unsafe_name.csv"
 
     runner = test_app.test_cli_runner()
     try:

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -1,0 +1,101 @@
+import csv
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from app import db
+from app.archive_utils import CUMULATIVE_ARCHIVE_FILENAME
+from app.models import Ticket, User
+
+
+def test_archive_weekly_cli_appends_previous_week_once(test_app):
+    """Weekly archive command appends the completed Sat-to-Sat week only once."""
+    pacific = ZoneInfo("America/Los_Angeles")
+    assistant = User(
+        username="weeklyhelper",
+        email="weeklyhelper@test.com",
+        name="Weekly Helper",
+    )
+    assistant.set_password("pass")
+    db.session.add(assistant)
+    db.session.commit()
+
+    inside_week = Ticket(
+        student_name="Inside Week",
+        table="T1",
+        physics_course="PH 211",
+        status="closed",
+        closed_reason="helped",
+        wa_id=assistant.id,
+        number_of_students=2,
+    )
+    inside_week.created_at = datetime(2026, 4, 20, 10, 0, tzinfo=pacific).astimezone(
+        timezone.utc
+    )
+    inside_week.closed_at = datetime(2026, 4, 20, 12, 0, tzinfo=pacific).astimezone(
+        timezone.utc
+    )
+
+    before_week = Ticket(
+        student_name="Before Week",
+        table="T2",
+        physics_course="PH 212",
+        status="closed",
+        closed_reason="helped",
+    )
+    before_week.created_at = datetime(2026, 4, 17, 20, 0, tzinfo=pacific).astimezone(
+        timezone.utc
+    )
+    before_week.closed_at = datetime(2026, 4, 17, 23, 59, tzinfo=pacific).astimezone(
+        timezone.utc
+    )
+
+    next_week_boundary = Ticket(
+        student_name="Next Week Boundary",
+        table="T3",
+        physics_course="PH 213",
+        status="closed",
+        closed_reason="helped",
+    )
+    next_week_boundary.created_at = datetime(
+        2026, 4, 24, 23, 0, tzinfo=pacific
+    ).astimezone(timezone.utc)
+    next_week_boundary.closed_at = datetime(
+        2026, 4, 25, 0, 0, tzinfo=pacific
+    ).astimezone(timezone.utc)
+
+    db.session.add_all([inside_week, before_week, next_week_boundary])
+    db.session.commit()
+
+    archive_path = Path(test_app.root_path) / "data" / "archives" / CUMULATIVE_ARCHIVE_FILENAME
+    if archive_path.exists():
+        archive_path.unlink()
+
+    runner = test_app.test_cli_runner()
+    first_run = runner.invoke(
+        args=["archive-weekly", "--now", "2026-04-25T00:00:00-07:00"]
+    )
+    assert first_run.exit_code == 0
+    assert "1 row(s) appended" in first_run.output
+    assert archive_path.exists()
+
+    with archive_path.open("r", encoding="utf-8", newline="") as archive_file:
+        rows = list(csv.DictReader(archive_file))
+
+    assert len(rows) == 1
+    assert rows[0]["Student Name"] == "Inside Week"
+    assert rows[0]["Assistant Name"] == "Weekly Helper"
+
+    second_run = runner.invoke(
+        args=["archive-weekly", "--now", "2026-04-25T00:00:00-07:00"]
+    )
+    assert second_run.exit_code == 0
+    assert "0 row(s) appended" in second_run.output
+    assert "1 duplicate row(s) skipped" in second_run.output
+
+    with archive_path.open("r", encoding="utf-8", newline="") as archive_file:
+        rows = list(csv.DictReader(archive_file))
+
+    assert len(rows) == 1
+
+    archive_path.unlink()

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -67,7 +67,9 @@ def test_archive_weekly_cli_appends_previous_week_once(test_app):
     db.session.add_all([inside_week, before_week, next_week_boundary])
     db.session.commit()
 
-    archive_path = Path(test_app.root_path) / "data" / "archives" / CUMULATIVE_ARCHIVE_FILENAME
+    archive_path = (
+        Path(test_app.root_path) / "data" / "archives" / CUMULATIVE_ARCHIVE_FILENAME
+    )
     if archive_path.exists():
         archive_path.unlink()
 

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -14,7 +14,7 @@ def test_archive_weekly_cli_appends_previous_week_once(test_app):
     assistant = User(
         username="weeklyhelper",
         email="weeklyhelper@test.com",
-        name="Weekly Helper",
+        name="=Weekly Helper",
     )
     assistant.set_password("pass")
     db.session.add(assistant)
@@ -91,7 +91,7 @@ def test_archive_weekly_cli_appends_previous_week_once(test_app):
         assert len(rows) == 1
         assert rows[0]["Student Name"] == "Inside Week"
         assert rows[0]["Status"] == "closed"
-        assert rows[0]["Assistant Name"] == "Weekly Helper"
+        assert rows[0]["Assistant Name"] == "'=Weekly Helper"
 
         second_run = runner.invoke(
             args=[
@@ -113,3 +113,49 @@ def test_archive_weekly_cli_appends_previous_week_once(test_app):
     finally:
         if archive_path.exists():
             archive_path.unlink()
+
+
+def test_archive_weekly_cli_confines_filename_to_archive_directory(test_app):
+    """CLI-provided archive names cannot escape the archive directory."""
+    pacific = ZoneInfo("America/Los_Angeles")
+    ticket = Ticket(
+        student_name="Safe Filename",
+        table="T1",
+        physics_course="PH 211",
+        status="closed",
+        closed_reason="helped",
+        number_of_students=1,
+    )
+    ticket.created_at = datetime(2026, 4, 20, 10, 0, tzinfo=pacific).astimezone(
+        timezone.utc
+    )
+    ticket.closed_at = datetime(2026, 4, 20, 12, 0, tzinfo=pacific).astimezone(
+        timezone.utc
+    )
+    db.session.add(ticket)
+    db.session.commit()
+
+    archive_dir = Path(test_app.root_path) / "data" / "archives"
+    archive_path = archive_dir / "unsafe_name.csv"
+    escaped_path = archive_dir.parent / "unsafe_name"
+
+    runner = test_app.test_cli_runner()
+    try:
+        result = runner.invoke(
+            args=[
+                "archive-weekly",
+                "--now",
+                "2026-04-25T00:00:00-07:00",
+                "--filename",
+                "../unsafe_name",
+            ]
+        )
+
+        assert result.exit_code == 0
+        assert archive_path.exists()
+        assert not escaped_path.exists()
+    finally:
+        if archive_path.exists():
+            archive_path.unlink()
+        if escaped_path.exists():
+            escaped_path.unlink()


### PR DESCRIPTION
Introduce a new app.archive_utils module that centralizes CSV archive generation, sanitization, query construction, and a Flask CLI command (archive-weekly) to append weekly ticket archives. Register the CLI in the application factory (create_app) and switch create_app default testing to False. Refactor views to reuse the new utilities (archive file listing/creation and archive directory handling) and use current_app for paths. Add systemd service and timer unit files and deployment docs to enable automatic Saturday midnight Pacific archives, and include tests for the weekly archive CLI behavior.