### PR TITLE
Auto flushing function

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -97,6 +97,7 @@ def create_app(testing=False):
     # in this file, it is intentional (for registering models and events).
     from app import models  # noqa: F401
     from app.archive_utils import register_archive_cli
+    from app.queue_maintenance import register_queue_maintenance_cli
     from app.routes import queue_events  # noqa: F401
     from app.routes.auth import auth_bp
     from app.routes.error import error_bp
@@ -108,6 +109,7 @@ def create_app(testing=False):
     app.register_blueprint(tickets_bp)
     app.register_blueprint(error_bp)
     register_archive_cli(app)
+    register_queue_maintenance_cli(app)
 
     # ---------------------------------------------------
     # Health Check Route

--- a/app/queue_maintenance.py
+++ b/app/queue_maintenance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import cast
 
 import click
 from flask import Flask
@@ -14,14 +15,17 @@ from app.models import Ticket
 def flush_open_tickets(reason: str = "Queue Flushed") -> int:
     """Close all active tickets and return how many were updated."""
     now = datetime.now(timezone.utc)
-    count = Ticket.query.filter(~Ticket.status.in_(["closed", "resolved"])).update(
-        {
-            Ticket.status: "closed",
-            Ticket.closed_reason: reason,
-            Ticket.closed_at: now,
-            Ticket.number_of_students: 0,
-        },
-        synchronize_session=False,
+    count = cast(
+        int,
+        Ticket.query.filter(~Ticket.status.in_(["closed", "resolved"])).update(
+            {
+                Ticket.status: "closed",
+                Ticket.closed_reason: reason,
+                Ticket.closed_at: now,
+                Ticket.number_of_students: 0,
+            },
+            synchronize_session=False,
+        ),
     )
 
     db.session.commit()

--- a/app/queue_maintenance.py
+++ b/app/queue_maintenance.py
@@ -1,0 +1,44 @@
+"""Queue maintenance helpers and CLI commands."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import click
+from flask import Flask
+
+from app import db
+from app.models import Ticket
+
+
+def flush_open_tickets(reason: str = "Queue Flushed") -> int:
+    """Close all active tickets and return how many were updated."""
+    now = datetime.now(timezone.utc)
+    count = Ticket.query.filter(~Ticket.status.in_(["closed", "resolved"])).update(
+        {
+            Ticket.status: "closed",
+            Ticket.closed_reason: reason,
+            Ticket.closed_at: now,
+            Ticket.number_of_students: 0,
+        },
+        synchronize_session=False,
+    )
+
+    db.session.commit()
+    return count
+
+
+def register_queue_maintenance_cli(app: Flask) -> None:
+    """Register queue maintenance commands on the Flask app."""
+
+    @app.cli.command("flush-open-tickets")
+    @click.option(
+        "--reason",
+        default="Queue Flushed",
+        show_default=True,
+        help="Reason stored in closed_reason for auto-closed tickets.",
+    )
+    def flush_open_tickets_command(reason: str) -> None:
+        """Close all non-closed/resolved tickets."""
+        count = flush_open_tickets(reason=reason)
+        click.echo(f"Nightly queue flush complete: {count} ticket(s) closed")

--- a/app/routes/views.py
+++ b/app/routes/views.py
@@ -1,4 +1,5 @@
 # app/routes/views.py
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from urllib.parse import urljoin, urlparse

--- a/app/routes/views.py
+++ b/app/routes/views.py
@@ -1,5 +1,4 @@
 # app/routes/views.py
-from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from urllib.parse import urljoin, urlparse
@@ -45,6 +44,7 @@ from app.forms import (
     TicketForm,
 )
 from app.models import Skipped, Ticket, User
+from app.queue_maintenance import flush_open_tickets
 from app.time_utils import (
     PACIFIC_TZ,
     format_pacific,
@@ -189,21 +189,7 @@ def flush():
         flash("Invalid request or session expired.", "error")
         return redirect(url_for("views.queue"))
 
-    # Use bulk UPDATE for performance
-    now = datetime.now(timezone.utc)
-
-    # Update all non-closed/resolved tickets
-    count = Ticket.query.filter(~Ticket.status.in_(["closed", "resolved"])).update(
-        {
-            Ticket.status: "closed",
-            Ticket.closed_reason: "Queue Flushed",
-            Ticket.closed_at: now,
-            Ticket.number_of_students: 0,
-        },
-        synchronize_session=False,
-    )
-
-    db.session.commit()
+    count = flush_open_tickets(reason="Queue Flushed")
 
     flash(f"Queue flushed. {count} tickets closed.", "info")
     return redirect(url_for("views.queue"))

--- a/deploy/DEPLOY_EC2_NGINX.md
+++ b/deploy/DEPLOY_EC2_NGINX.md
@@ -93,3 +93,27 @@ To run this automatically every Saturday at midnight Pacific using systemd:
    - `sudo journalctl -u wormhole-weekly-archive.service -n 50`
 
 The timer uses `Timezone=America/Los_Angeles`. If your systemd version does not support that setting, set the server timezone with `sudo timedatectl set-timezone America/Los_Angeles`, remove the `Timezone=` line, then reload systemd.
+
+## 8) Enable automatic nightly queue flush
+
+The app includes a Flask CLI command that closes all active tickets (`live` and `in_progress`) with reason `Queue Flushed`:
+
+```bash
+source venv/bin/activate
+export FLASK_APP=application:application
+flask flush-open-tickets --reason "Queue Flushed"
+```
+
+To run this automatically every day at midnight Pacific using systemd:
+
+1. Copy the timer and service files:
+   - `sudo cp deploy/systemd/wormhole-nightly-flush.service /etc/systemd/system/wormhole-nightly-flush.service`
+   - `sudo cp deploy/systemd/wormhole-nightly-flush.timer /etc/systemd/system/wormhole-nightly-flush.timer`
+2. Reload systemd and enable the timer:
+   - `sudo systemctl daemon-reload`
+   - `sudo systemctl enable --now wormhole-nightly-flush.timer`
+3. Verify the timer:
+   - `systemctl list-timers wormhole-nightly-flush.timer`
+   - `sudo journalctl -u wormhole-nightly-flush.service -n 50`
+
+The timer uses `Timezone=America/Los_Angeles`. If your systemd version does not support that setting, set the server timezone with `sudo timedatectl set-timezone America/Los_Angeles`, remove the `Timezone=` line, then reload systemd.

--- a/deploy/systemd/wormhole-nightly-flush.service
+++ b/deploy/systemd/wormhole-nightly-flush.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Flush active Wormhole queue tickets nightly
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=ec2-user
+Group=ec2-user
+WorkingDirectory=/home/ec2-user/CS461-wormhole-queue-system
+EnvironmentFile=/etc/wormhole/wormhole.env
+Environment=FLASK_APP=application:application
+ExecStart=/home/ec2-user/CS461-wormhole-queue-system/venv/bin/flask flush-open-tickets --reason "Queue Flushed"

--- a/deploy/systemd/wormhole-nightly-flush.timer
+++ b/deploy/systemd/wormhole-nightly-flush.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run Wormhole nightly queue flush at midnight Pacific
+
+[Timer]
+OnCalendar=*-*-* 00:00:00
+Timezone=America/Los_Angeles
+Persistent=true
+Unit=wormhole-nightly-flush.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_queue_maintenance.py
+++ b/tests/test_queue_maintenance.py
@@ -6,7 +6,9 @@ from app.models import Ticket
 
 def test_flush_open_tickets_cli_closes_live_and_in_progress(test_app):
     """CLI flush should close active tickets and leave closed/resolved unchanged."""
-    live = Ticket(student_name="Live", table="T1", physics_course="Ph 211", status="live")
+    live = Ticket(
+        student_name="Live", table="T1", physics_course="Ph 211", status="live"
+    )
     in_progress = Ticket(
         student_name="InProgress",
         table="T2",

--- a/tests/test_queue_maintenance.py
+++ b/tests/test_queue_maintenance.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timedelta, timezone
+
+from app import db
+from app.models import Ticket
+
+
+def test_flush_open_tickets_cli_closes_live_and_in_progress(test_app):
+    """CLI flush should close active tickets and leave closed/resolved unchanged."""
+    live = Ticket(student_name="Live", table="T1", physics_course="Ph 211", status="live")
+    in_progress = Ticket(
+        student_name="InProgress",
+        table="T2",
+        physics_course="Ph 212",
+        status="in_progress",
+        number_of_students=3,
+    )
+    closed = Ticket(
+        student_name="Closed",
+        table="T3",
+        physics_course="Ph 213",
+        status="closed",
+        closed_reason="helped",
+        closed_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        number_of_students=2,
+    )
+    resolved = Ticket(
+        student_name="Resolved",
+        table="T4",
+        physics_course="Ph 214",
+        status="resolved",
+        closed_reason="duplicate",
+        closed_at=datetime.now(timezone.utc) - timedelta(hours=2),
+        number_of_students=0,
+    )
+
+    db.session.add_all([live, in_progress, closed, resolved])
+    db.session.commit()
+
+    runner = test_app.test_cli_runner()
+    result = runner.invoke(args=["flush-open-tickets", "--reason", "Queue Flushed"])
+
+    assert result.exit_code == 0
+    assert "2 ticket(s) closed" in result.output
+
+    db.session.refresh(live)
+    db.session.refresh(in_progress)
+    db.session.refresh(closed)
+    db.session.refresh(resolved)
+
+    for ticket in (live, in_progress):
+        assert ticket.status == "closed"
+        assert ticket.closed_reason == "Queue Flushed"
+        assert ticket.closed_at is not None
+        assert ticket.number_of_students == 0
+
+    assert closed.status == "closed"
+    assert closed.closed_reason == "helped"
+    assert resolved.status == "resolved"
+    assert resolved.closed_reason == "duplicate"


### PR DESCRIPTION
This pull request introduces a new queue maintenance feature that allows all active tickets to be closed in bulk, both via a Flask CLI command and through the web interface. It also includes documentation and systemd integration for automated nightly queue maintenance. The most important changes are grouped below:

**Queue Maintenance Functionality:**

* Added a new `flush_open_tickets` function and a corresponding Flask CLI command (`flush-open-tickets`) in `app/queue_maintenance.py` to close all active tickets with a specified reason. This promotes code reuse and allows both manual and automated queue flushing.
* Updated the web route handler in `app/routes/views.py` to use the new `flush_open_tickets` function, simplifying the code and ensuring consistency between CLI and web-based queue flushing. 

**Integration and Registration:**

* Registered the new queue maintenance CLI with the Flask application in `app/__init__.py`, enabling the CLI command to be available in the app context. 

**Automation and Deployment:**

* Added a new section to the deployment documentation (`deploy/DEPLOY_EC2_NGINX.md`) explaining how to set up a systemd timer and service to run the nightly queue flush automatically.
* Introduced new systemd unit files (`deploy/systemd/wormhole-nightly-flush.service` and `deploy/systemd/wormhole-nightly-flush.timer`) to automate the nightly execution of the queue flush CLI command at midnight Pacific time.

**Testing:**

* Added a new test (`tests/test_queue_maintenance.py`) to verify that the CLI command correctly closes only active tickets and leaves closed/resolved tickets unchanged.