### PR TITLE
Use closed_reason in archive CSV rows

### DIFF
--- a/app/archive_utils.py
+++ b/app/archive_utils.py
@@ -135,7 +135,7 @@ def ticket_archive_row(ticket: Ticket) -> list[object]:
         sanitize_csv_value(ticket.student_name),
         sanitize_csv_value(ticket.table),
         sanitize_csv_value(ticket.physics_course),
-        ticket.status,
+        ticket.closed_reason if ticket.closed_reason else "Not Provided",
         format_pacific(ticket.created_at, "%Y-%m-%d %H:%M:%S"),
         format_pacific(ticket.closed_at, "%Y-%m-%d %H:%M:%S"),
         ticket.number_of_students,

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -90,7 +90,7 @@ def test_archive_weekly_cli_appends_previous_week_once(test_app):
 
         assert len(rows) == 1
         assert rows[0]["Student Name"] == "Inside Week"
-        assert rows[0]["Status"] == "closed"
+        assert rows[0]["Status"] == "helped"
         assert rows[0]["Created At"] == "2026-04-20 10:00:00"
         assert rows[0]["Closed At"] == "2026-04-20 12:00:00"
         assert rows[0]["Assistant Name"] == "'=Weekly Helper"


### PR DESCRIPTION
Replace ticket.status with ticket.closed_reason in ticket_archive_row and fallback to "Not Provided" when closed_reason is empty. This ensures archived CSV rows include the ticket closure reason instead of the status and avoids empty fields.