### PR TITLE
Include ticket ID in queue listing

### DIFF
--- a/app/templates/queue.html
+++ b/app/templates/queue.html
@@ -41,7 +41,7 @@
                     {% for tk in ol %}
                         <li>
                             <a href="{{ url_for('views.pastticket', username=user.username, tktid=tk.id, next=url_for('views.queue') ) }}">
-                                {{ tk.name }} — {{ tk.phClass }} (Table {{ tk.table }})
+                                {{ tk.id }} - {{ tk.name }} — {{ tk.phClass }} (Table {{ tk.table }})
                             </a>
                         </li>
                     {% endfor %}
@@ -55,7 +55,7 @@
                     {% for tk in cul %}
                         <li>
                             <a href="{{ url_for('views.currentticket', tktid=tk.id) }}">
-                                {{ tk.name }} (Table {{ tk.table }}) - {{ tk.assigned_to }}
+                                {{ tk.id }} - {{ tk.name }} (Table {{ tk.table }}) - {{ tk.assigned_to }}
                             </a>
                         </li>
                     {% endfor %}


### PR DESCRIPTION
Prepend the ticket ID to displayed entries in the queue template for both past and current ticket lists (app/templates/queue.html). This is a presentation-only change to make tickets uniquely identifiable in the list (e.g. "123 - Name — Class (Table 4)"), no behavior or routing changes.