### PR TITLE
Add join reminders for Zoom/Teams tickets

### DIFF
--- a/app/routes/views.py
+++ b/app/routes/views.py
@@ -376,7 +376,18 @@ def create_ticket_page():
         except Exception:
             pass
 
-        flash("Ticket created — thank you!", "success")
+        join_target = {
+            "zoom": "Zoom",
+            "teams": "Teams",
+        }.get((form.location.data or "").strip().lower())
+
+        if join_target:
+            flash(
+                f"Ticket created - thank you! Please join {join_target} now.",
+                "success",
+            )
+        else:
+            flash("Ticket created - thank you!", "success")
         return redirect(url_for("views.livequeue"))
 
     return render_template("createticket.html", form=form)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -78,6 +78,38 @@ def test_homepage_preserves_static_links_when_content_is_dynamic(test_client):
     assert b"MS_Teams_Instructions.pdf" in response.data
 
 
+def test_create_ticket_flash_reminds_to_join_zoom(test_client):
+    """Creating a Zoom ticket should include a Zoom join reminder."""
+    response = test_client.post(
+        "/createticket",
+        data={
+            "name": "Test Student",
+            "phClass": "Ph 211",
+            "location": "Zoom",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Ticket created - thank you! Please join Zoom now." in response.data
+
+
+def test_create_ticket_flash_reminds_to_join_teams(test_client):
+    """Creating a Teams ticket should include a Teams join reminder."""
+    response = test_client.post(
+        "/createticket",
+        data={
+            "name": "Test Student",
+            "phClass": "Ph 211",
+            "location": "Teams",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Ticket created - thank you! Please join Teams now." in response.data
+
+
 def test_site_content_editor_requires_login(test_client):
     """The website editor should be protected from anonymous users."""
     response = test_client.get("/admin/site-content")


### PR DESCRIPTION
Include a join reminder in the ticket-created flash message when the submitted location is Zoom or Teams (case-insensitive). The view maps normalized location values to a friendly name and shows "Please join <Platform> now." Otherwise the original success message is used. Added tests to verify Zoom and Teams reminders are displayed after creating a ticket.