### PR TITLE
Fix/ses forgot password sender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ marimo/_lsp/
 __marimo__/
 app.db
 *.pem
+app/data/archives/wormhole_archive_2026-05-16_to_2026-05-17.csv

--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ If a browser keeps trying HTTPS after a previous redirect, clear the browser's c
 
 For production deployment, configure environment variables such as `APP_ENV=production`, `SECRET_KEY`, `DATABASE_URL`, `FORCE_HTTPS=1`, `ENABLE_HSTS=1`, `SESSION_COOKIE_SECURE=1`, and `PREFERRED_URL_SCHEME=https`. See the deployment documentation in `deploy/` for more details.
 
+### Forgot-Password Email Configuration
+
+Password reset emails are sent through Amazon SES. The production sender should use the verified `physics.oregonstate.edu` SES domain identity:
+
+```env
+SES_REGION=us-west-2
+MAIL_DEFAULT_SENDER="Wormhole Physics <no-reply@physics.oregonstate.edu>"
+MAIL_REPLY_TO="Wormhole Physics <Wormhole.Physics@oregonstate.edu>"
+EMAIL_ENABLED=1
+RESET_PASSWORD_TOKEN_MAX_AGE=3600
+```
+
+`MAIL_DEFAULT_SENDER` is the automated transactional sender. `MAIL_REPLY_TO` routes human replies to the monitored Wormhole inbox. Do not commit AWS access keys or any real secret values. On AWS, credentials should come from the instance role, Elastic Beanstalk environment, Parameter Store, Secrets Manager, or another approved deployment mechanism.
+
 ## System Requirements
 
 - Python 3.12 or newer

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -48,6 +48,7 @@ def create_app(testing=False):
         app.config["FORCE_HTTPS"] = False
         app.config["ENABLE_HSTS"] = False
         app.config["PREFERRED_URL_SCHEME"] = "http"
+        app.config["EMAIL_ENABLED"] = False
     elif (
         os.environ.get("REQUIRE_DATABASE_URL") == "1"
         and not os.environ.get("DATABASE_URL")

--- a/app/email.py
+++ b/app/email.py
@@ -1,0 +1,72 @@
+"""Email helpers for Wormhole transactional messages."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from flask import current_app, render_template, url_for
+
+if TYPE_CHECKING:
+    from app.models import User
+
+
+def _ses_client():
+    """Create an Amazon SES client using the configured AWS region."""
+    import boto3
+
+    return boto3.client("ses", region_name=current_app.config["SES_REGION"])
+
+
+def send_email(
+    subject: str,
+    recipients: list[str],
+    text_body: str,
+    html_body: str,
+) -> None:
+    """Send a transactional email through Amazon SES.
+
+    Email delivery can be disabled for local development and tests with
+    EMAIL_ENABLED=0. When disabled, this function logs the skipped send without
+    exposing reset tokens or other sensitive message contents.
+    """
+    if not current_app.config.get("EMAIL_ENABLED", True):
+        current_app.logger.info(
+            "Email sending disabled; skipped transactional email to %s",
+            ", ".join(recipients),
+        )
+        return
+
+    reply_to = current_app.config.get("MAIL_REPLY_TO")
+    request: dict[str, object] = {
+        "Source": current_app.config["MAIL_DEFAULT_SENDER"],
+        "Destination": {"ToAddresses": recipients},
+        "Message": {
+            "Subject": {"Data": subject, "Charset": "UTF-8"},
+            "Body": {
+                "Text": {"Data": text_body, "Charset": "UTF-8"},
+                "Html": {"Data": html_body, "Charset": "UTF-8"},
+            },
+        },
+    }
+
+    if reply_to:
+        request["ReplyToAddresses"] = [reply_to]
+
+    _ses_client().send_email(**request)
+
+
+def send_password_reset_email(user: "User") -> None:
+    """Send a password reset email to an existing active user."""
+    token = user.get_reset_password_token()
+    reset_url = url_for("auth.reset_password", token=token, _external=True)
+
+    send_email(
+        subject="Reset your Wormhole password",
+        recipients=[user.email],
+        text_body=render_template(
+            "email/reset_password.txt", user=user, reset_url=reset_url
+        ),
+        html_body=render_template(
+            "email/reset_password.html", user=user, reset_url=reset_url
+        ),
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -14,6 +14,8 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import sqlalchemy as sa
+from flask import current_app
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from sqlalchemy import orm
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -79,6 +81,35 @@ class User(Base):
         if not self.password_hash:
             return False
         return check_password_hash(self.password_hash, password)
+
+    def get_reset_password_token(self) -> str:
+        """Return a signed, time-limited password reset token for this user."""
+        serializer = URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
+        return serializer.dumps(
+            {"reset_password": self.id},
+            salt=current_app.config["RESET_PASSWORD_TOKEN_SALT"],
+        )
+
+    @staticmethod
+    def verify_reset_password_token(token: str) -> Optional["User"]:
+        """Return the user for a valid reset token, or None if invalid/expired."""
+        serializer = URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
+        try:
+            data = serializer.loads(
+                token,
+                salt=current_app.config["RESET_PASSWORD_TOKEN_SALT"],
+                max_age=current_app.config["RESET_PASSWORD_TOKEN_MAX_AGE"],
+            )
+        except (BadSignature, SignatureExpired):
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        user_id = data.get("reset_password")
+        if not isinstance(user_id, int):
+            return None
+        return db.session.get(User, user_id)
 
     def claim_ticket(self, ticket: "Ticket") -> bool:
         if ticket.wa_id is None:

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,4 +1,5 @@
 # app/routes/auth.py
+import sqlalchemy as sa
 from flask import (
     Blueprint,
     current_app,
@@ -11,6 +12,8 @@ from flask import (
     url_for,
 )
 
+from app import db
+from app.email import send_password_reset_email
 from app.forms import ResetPasswordForm, ResetPasswordRequestForm
 from app.models import User
 
@@ -76,9 +79,18 @@ def reset_password_request():
     form = ResetPasswordRequestForm()
     if request.method == "POST":
         if form.validate_on_submit():
-            # Variable assignment removed to satisfy Ruff F841 (unused variable)
-            # Actual email sending logic would be implemented here
-            current_app.logger.info(f"Password reset requested for: {form.email.data}")
+            email = form.email.data.strip().lower()
+            user = User.query.filter(sa.func.lower(User.email) == email).first()
+            current_app.logger.info("Password reset requested for: %s", email)
+
+            if user and user.is_active:
+                try:
+                    send_password_reset_email(user)
+                except Exception:
+                    current_app.logger.exception(
+                        "Password reset email failed for user id %s", user.id
+                    )
+
         flash(
             "If an account with that email exists, check your inbox for reset instructions.",
             "info",
@@ -92,13 +104,19 @@ def reset_password_request():
 # -------------------------------
 @auth_bp.route("/reset_password/<token>", methods=["GET", "POST"])
 def reset_password(token):
-    # Log the token to satisfy the "unused variable" check
-    current_app.logger.info(f"Password reset page accessed with token: {token}")
+    user = User.verify_reset_password_token(token)
+    if user is None or not user.is_active:
+        flash("That password reset link is invalid or has expired.", "error")
+        return redirect(url_for("auth.reset_password_request"))
+
     form = ResetPasswordForm()
     if request.method == "POST":
         if not form.validate_on_submit():
             flash("Passwords do not match or are invalid.", "error")
             return render_template("reset_password.html", form=form)
+
+        user.set_password(form.password.data)
+        db.session.commit()
         flash("Your password has been reset. You may now sign in.", "success")
         return redirect(url_for("views.assistant_login"))
     return render_template("reset_password.html", form=form)

--- a/app/templates/email/reset_password.html
+++ b/app/templates/email/reset_password.html
@@ -1,0 +1,9 @@
+<p>
+    A password reset was requested for your Wormhole account.
+</p>
+<p>
+    <a href="{{ reset_url }}">Reset your password</a>
+</p>
+<p>
+    If you did not request this password reset, you can ignore this email.
+</p>

--- a/app/templates/email/reset_password.txt
+++ b/app/templates/email/reset_password.txt
@@ -1,0 +1,7 @@
+A password reset was requested for your Wormhole account.
+
+To reset your password, open the link below:
+
+{{ reset_url }}
+
+If you did not request this password reset, you can ignore this email.

--- a/config.py
+++ b/config.py
@@ -35,6 +35,24 @@ class Config:
     FORCE_HTTPS = _env_bool("FORCE_HTTPS", _DEFAULT_SECURE)
     ENABLE_HSTS = _env_bool("ENABLE_HSTS", _DEFAULT_SECURE)
 
+    # Amazon SES / transactional email settings for password reset emails.
+    SES_REGION = os.environ.get("SES_REGION", "us-west-2")
+    MAIL_DEFAULT_SENDER = os.environ.get(
+        "MAIL_DEFAULT_SENDER",
+        "Wormhole Physics <no-reply@physics.oregonstate.edu>",
+    )
+    MAIL_REPLY_TO = os.environ.get(
+        "MAIL_REPLY_TO",
+        "Wormhole Physics <Wormhole.Physics@oregonstate.edu>",
+    )
+    EMAIL_ENABLED = _env_bool("EMAIL_ENABLED", _DEFAULT_SECURE)
+    RESET_PASSWORD_TOKEN_MAX_AGE = int(
+        os.environ.get("RESET_PASSWORD_TOKEN_MAX_AGE", "3600")
+    )
+    RESET_PASSWORD_TOKEN_SALT = os.environ.get(
+        "RESET_PASSWORD_TOKEN_SALT", "password-reset-salt"
+    )
+
     # In production (Elastic Beanstalk), DATABASE_URL must be set as an
     # environment variable pointing to an RDS instance.
     # The SQLite fallback is kept only for local development.

--- a/deploy/systemd/wormhole.env.example
+++ b/deploy/systemd/wormhole.env.example
@@ -16,3 +16,13 @@ FORCE_HTTPS=1
 ENABLE_HSTS=1
 SESSION_COOKIE_SECURE=1
 PREFERRED_URL_SCHEME=https
+
+# Amazon SES transactional email settings for forgot-password emails
+SES_REGION=us-west-2
+MAIL_DEFAULT_SENDER="Wormhole Physics <no-reply@physics.oregonstate.edu>"
+MAIL_REPLY_TO="Wormhole Physics <Wormhole.Physics@oregonstate.edu>"
+EMAIL_ENABLED=1
+RESET_PASSWORD_TOKEN_MAX_AGE=3600
+# Optional: set a unique salt if rotating all existing reset links is desired.
+# RESET_PASSWORD_TOKEN_SALT=password-reset-salt
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ idna==3.11
 dnspython==2.8.0
 tzdata
 eventlet
+boto3==1.35.99

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -1,0 +1,125 @@
+from app import db
+from app.email import send_email
+from app.models import User
+
+
+def _create_user(email="helper@oregonstate.edu", password="old-password", active=True):
+    user = User(username=email.split("@")[0], email=email, is_active=active)
+    user.set_password(password)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def test_password_reset_request_sends_email_for_active_user(test_client, monkeypatch):
+    user = _create_user()
+    sent_to = []
+
+    def fake_send_password_reset_email(found_user):
+        sent_to.append(found_user.email)
+
+    monkeypatch.setattr(
+        "app.routes.auth.send_password_reset_email", fake_send_password_reset_email
+    )
+
+    response = test_client.post(
+        "/reset_password_request",
+        data={"email": "Helper@OregonState.edu"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert sent_to == [user.email]
+    assert b"If an account with that email exists" in response.data
+
+
+def test_password_reset_request_does_not_reveal_unknown_email(test_client, monkeypatch):
+    sent_to = []
+
+    def fake_send_password_reset_email(found_user):
+        sent_to.append(found_user.email)
+
+    monkeypatch.setattr(
+        "app.routes.auth.send_password_reset_email", fake_send_password_reset_email
+    )
+
+    response = test_client.post(
+        "/reset_password_request",
+        data={"email": "missing@oregonstate.edu"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert sent_to == []
+    assert b"If an account with that email exists" in response.data
+    assert b"No account" not in response.data
+
+
+def test_password_reset_token_changes_password(test_client):
+    user = _create_user()
+    token = user.get_reset_password_token()
+
+    response = test_client.post(
+        f"/reset_password/{token}",
+        data={"password": "new-password", "password2": "new-password"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    db.session.refresh(user)
+    assert user.check_password("new-password")
+    assert not user.check_password("old-password")
+    assert b"Your password has been reset" in response.data
+
+
+def test_invalid_password_reset_token_is_rejected(test_client):
+    response = test_client.get(
+        "/reset_password/not-a-real-token", follow_redirects=True
+    )
+
+    assert response.status_code == 200
+    assert b"That password reset link is invalid or has expired" in response.data
+
+
+def test_send_email_uses_configured_ses_sender_and_reply_to(test_app, monkeypatch):
+    calls = []
+
+    class FakeSesClient:
+        def send_email(self, **kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setattr("app.email._ses_client", lambda: FakeSesClient())
+
+    test_app.config["EMAIL_ENABLED"] = True
+    test_app.config[
+        "MAIL_DEFAULT_SENDER"
+    ] = "Wormhole Physics <no-reply@physics.oregonstate.edu>"
+    test_app.config[
+        "MAIL_REPLY_TO"
+    ] = "Wormhole Physics <Wormhole.Physics@oregonstate.edu>"
+
+    with test_app.app_context():
+        send_email(
+            subject="Reset your Wormhole password",
+            recipients=["helper@oregonstate.edu"],
+            text_body="Reset text",
+            html_body="<p>Reset HTML</p>",
+        )
+
+    assert calls == [
+        {
+            "Source": "Wormhole Physics <no-reply@physics.oregonstate.edu>",
+            "Destination": {"ToAddresses": ["helper@oregonstate.edu"]},
+            "Message": {
+                "Subject": {
+                    "Data": "Reset your Wormhole password",
+                    "Charset": "UTF-8",
+                },
+                "Body": {
+                    "Text": {"Data": "Reset text", "Charset": "UTF-8"},
+                    "Html": {"Data": "<p>Reset HTML</p>", "Charset": "UTF-8"},
+                },
+            },
+            "ReplyToAddresses": ["Wormhole Physics <Wormhole.Physics@oregonstate.edu>"],
+        }
+    ]


### PR DESCRIPTION
## Testing

- Confirmed the forgot-password route reaches the SES sending layer locally.
- Confirmed local SES failure was due to missing local AWS credentials, not route/token logic.
- Confirmed AWS server can send from `Wormhole Physics <no-reply@physics.oregonstate.edu>` using SES.
- Confirmed SES returned HTTP 200 and a MessageId from the AWS server.
- Final end-to-end reset email test will be completed after deployment.