### PR TITLE
Show admin status in user list and add tests to cover

### DIFF
--- a/app/templates/user_list.html
+++ b/app/templates/user_list.html
@@ -11,9 +11,12 @@
                         <th>
                             Current Users
                         </th>
+                        <th>
+                            Admin
+                        </th>
                     </tr>
                     <tr>
-                        <td>
+                        <td colspan="2">
                             <form action="{{ url_for('views.download_current_users') }}" method="get">
                                 <button type="submit">
                                     Download Current Users
@@ -28,6 +31,9 @@
                                     {{ u.name or u.username }}
                                 </a>
                             </td>
+                            <td>
+                                {{ 'Yes' if u.is_admin else 'No' }}
+                            </td>
                         </tr>
                     {% endfor %}
                 </table>
@@ -36,9 +42,12 @@
                         <th>
                             Old Users
                         </th>
+                        <th>
+                            Admin
+                        </th>
                     </tr>
                     <tr>
-                        <td>
+                        <td colspan="2">
                             <form action="{{ url_for('views.download_old_users') }}" method="get">
                                 <button type="submit">
                                     Download Old Users
@@ -52,6 +61,9 @@
                                 <a href="{{ url_for('views.delete_user', username=u.username) }}">
                                     {{ u.name or u.username }}
                                 </a>
+                            </td>
+                            <td>
+                                {{ 'Yes' if u.is_admin else 'No' }}
                             </td>
                         </tr>
                     {% endfor %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -588,6 +588,40 @@ def test_download_old_users_csv_rejects_non_admin(test_client):
     assert response.get_json() == {"error": "Admin access required"}
 
 
+def test_user_list_shows_admin_status_column(test_client):
+    """User list page should show admin status for each listed user."""
+    admin = User(
+        username="admin_user_list_status", email="adminstatus@test.com", is_admin=True
+    )
+    admin.set_password("pass")
+
+    non_admin = User(
+        username="regular_user_list_status",
+        email="regularstatus@test.com",
+        name="Regular Status",
+        is_admin=False,
+        is_active=True,
+    )
+    non_admin.set_password("pass")
+
+    db.session.add_all([admin, non_admin])
+    db.session.commit()
+
+    with test_client.session_transaction() as sess:
+        sess["user_id"] = admin.id
+        sess["is_admin"] = True
+
+    response = test_client.get("/user_list")
+    assert response.status_code == 200
+
+    html = response.data.decode("utf-8")
+    assert "Admin" in html
+    assert "admin_user_list_status" in html
+    assert "Regular Status" in html
+    assert "Yes" in html
+    assert "No" in html
+
+
 def test_download_current_users_csv_sanitizes_formula_cells(test_client):
     """CSV export should neutralize spreadsheet formula-leading values."""
     admin = User(


### PR DESCRIPTION
Add an 'Admin' column to app/templates/user_list.html for both Current and Old Users, adjust table cell colspan for the download buttons, and render 'Yes' or 'No' based on u.is_admin. Add test_user_list_shows_admin_status_column in tests/test_routes.py to create admin and non-admin users, load /user_list as an admin, and assert the Admin header and Yes/No indicators (and user names) are present.