### PR TITLE
Sort archive tickets by ID descending

### DIFF
--- a/app/archive_utils.py
+++ b/app/archive_utils.py
@@ -274,8 +274,10 @@ def append_weekly_archive(
     """Append the latest completed week of tickets to the cumulative archive CSV."""
     start_utc, end_utc = previous_saturday_week_bounds(now)
     archive_path = archive_dir(root_path) / safe_archive_filename(filename)
-    tickets = archive_ticket_query(start_utc, end_utc, include_end=False).yield_per(
-        1000
+    tickets = sorted(
+        archive_ticket_query(start_utc, end_utc, include_end=False).yield_per(1000),
+        key=lambda ticket: ticket.id,
+        reverse=True,
     )
 
     existing_keys = _existing_archive_keys(archive_path)

--- a/app/archive_utils.py
+++ b/app/archive_utils.py
@@ -274,10 +274,11 @@ def append_weekly_archive(
     """Append the latest completed week of tickets to the cumulative archive CSV."""
     start_utc, end_utc = previous_saturday_week_bounds(now)
     archive_path = archive_dir(root_path) / safe_archive_filename(filename)
-    tickets = sorted(
-        archive_ticket_query(start_utc, end_utc, include_end=False).yield_per(1000),
-        key=lambda ticket: ticket.id,
-        reverse=True,
+    tickets = (
+        archive_ticket_query(start_utc, end_utc, include_end=False)
+        .order_by(None)
+        .order_by(Ticket.id.desc())
+        .yield_per(1000)
     )
 
     existing_keys = _existing_archive_keys(archive_path)

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -31,14 +31,10 @@ def test_archive_weekly_cli_appends_previous_week_once(test_app):
     )
     newer_inside_week.created_at = datetime(
         2026, 4, 20, 10, 0, tzinfo=pacific
-    ).astimezone(
-        timezone.utc
-    )
+    ).astimezone(timezone.utc)
     newer_inside_week.closed_at = datetime(
         2026, 4, 20, 12, 0, tzinfo=pacific
-    ).astimezone(
-        timezone.utc
-    )
+    ).astimezone(timezone.utc)
 
     older_inside_week = Ticket(
         student_name="Older Inside Week",

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -20,8 +20,8 @@ def test_archive_weekly_cli_appends_previous_week_once(test_app):
     db.session.add(assistant)
     db.session.commit()
 
-    inside_week = Ticket(
-        student_name="Inside Week",
+    newer_inside_week = Ticket(
+        student_name="Newer Inside Week",
         table="T1",
         physics_course="PH 211",
         status="closed",
@@ -29,17 +29,37 @@ def test_archive_weekly_cli_appends_previous_week_once(test_app):
         wa_id=assistant.id,
         number_of_students=2,
     )
-    inside_week.created_at = datetime(2026, 4, 20, 10, 0, tzinfo=pacific).astimezone(
+    newer_inside_week.created_at = datetime(
+        2026, 4, 20, 10, 0, tzinfo=pacific
+    ).astimezone(
         timezone.utc
     )
-    inside_week.closed_at = datetime(2026, 4, 20, 12, 0, tzinfo=pacific).astimezone(
+    newer_inside_week.closed_at = datetime(
+        2026, 4, 20, 12, 0, tzinfo=pacific
+    ).astimezone(
         timezone.utc
     )
 
-    before_week = Ticket(
-        student_name="Before Week",
+    older_inside_week = Ticket(
+        student_name="Older Inside Week",
         table="T2",
         physics_course="PH 212",
+        status="closed",
+        closed_reason="helped",
+        wa_id=assistant.id,
+        number_of_students=1,
+    )
+    older_inside_week.created_at = datetime(
+        2026, 4, 20, 9, 0, tzinfo=pacific
+    ).astimezone(timezone.utc)
+    older_inside_week.closed_at = datetime(
+        2026, 4, 20, 11, 0, tzinfo=pacific
+    ).astimezone(timezone.utc)
+
+    before_week = Ticket(
+        student_name="Before Week",
+        table="T3",
+        physics_course="PH 213",
         status="closed",
         closed_reason="helped",
     )
@@ -64,7 +84,9 @@ def test_archive_weekly_cli_appends_previous_week_once(test_app):
         2026, 4, 25, 0, 0, tzinfo=pacific
     ).astimezone(timezone.utc)
 
-    db.session.add_all([inside_week, before_week, next_week_boundary])
+    db.session.add_all(
+        [newer_inside_week, older_inside_week, before_week, next_week_boundary]
+    )
     db.session.commit()
 
     archive_filename = f"wormhole_archive_weekly_cli_{uuid4().hex}.csv"
@@ -82,17 +104,19 @@ def test_archive_weekly_cli_appends_previous_week_once(test_app):
             ]
         )
         assert first_run.exit_code == 0
-        assert "1 row(s) appended" in first_run.output
+        assert "2 row(s) appended" in first_run.output
         assert archive_path.exists()
 
         with archive_path.open("r", encoding="utf-8", newline="") as archive_file:
             rows = list(csv.DictReader(archive_file))
 
-        assert len(rows) == 1
-        assert rows[0]["Student Name"] == "Inside Week"
+        assert len(rows) == 2
+        assert rows[0]["Student Name"] == "Older Inside Week"
+        assert rows[1]["Student Name"] == "Newer Inside Week"
+        assert int(rows[0]["Ticket ID"]) > int(rows[1]["Ticket ID"])
         assert rows[0]["Status"] == "helped"
-        assert rows[0]["Created At"] == "2026-04-20 10:00:00"
-        assert rows[0]["Closed At"] == "2026-04-20 12:00:00"
+        assert rows[0]["Created At"] == "2026-04-20 09:00:00"
+        assert rows[0]["Closed At"] == "2026-04-20 11:00:00"
         assert rows[0]["Assistant Name"] == "'=Weekly Helper"
 
         second_run = runner.invoke(
@@ -106,12 +130,12 @@ def test_archive_weekly_cli_appends_previous_week_once(test_app):
         )
         assert second_run.exit_code == 0
         assert "0 row(s) appended" in second_run.output
-        assert "1 duplicate row(s) skipped" in second_run.output
+        assert "2 duplicate row(s) skipped" in second_run.output
 
         with archive_path.open("r", encoding="utf-8", newline="") as archive_file:
             rows = list(csv.DictReader(archive_file))
 
-        assert len(rows) == 1
+        assert len(rows) == 2
     finally:
         if archive_path.exists():
             archive_path.unlink()


### PR DESCRIPTION
Wrap the ticket query in sorted(..., key=lambda ticket: ticket.id, reverse=True) in append_weekly_archive to enforce a deterministic (ID-descending) ordering before writing the archive. Update tests to reflect the new ordering and behavior: add an additional ticket fixture, rename variables for clarity, adjust created/closed timestamps, and update expectations (2 rows appended, 2 duplicates skipped, ordering and timestamp assertions). This ensures consistent archive row order and predictable duplicate handling.