### PR TITLE
Treat hardware timestamps as Pacific

### DIFF
--- a/app/routes/views.py
+++ b/app/routes/views.py
@@ -534,16 +534,24 @@ def _parse_hardware_timestamp(value):
         return datetime.fromtimestamp(value, timezone.utc)
 
     if isinstance(value, str):
+        # Support ISO 8601 strings with trailing Z (UTC designator).
+        normalized = value.strip()
+        if normalized.endswith("Z"):
+            normalized = f"{normalized[:-1]}+00:00"
+
         try:
-            parsed = datetime.fromisoformat(value)
+            parsed = datetime.fromisoformat(normalized)
         except ValueError:
             try:
-                parsed = datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+                parsed = datetime.strptime(normalized, "%Y-%m-%d %H:%M:%S")
             except ValueError:
                 return datetime.now(timezone.utc)
+
         if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
-        return parsed
+            # Hardware clients often send local clock time without an offset.
+            # Interpret these values as Pacific local time before storing in UTC.
+            parsed = parsed.replace(tzinfo=PACIFIC_TZ)
+        return parsed.astimezone(timezone.utc)
 
     return datetime.now(timezone.utc)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -53,6 +53,19 @@ def test_hardware_api_creates_and_updates_box(test_client):
     assert box.status == "Green"
 
 
+def test_hardware_api_treats_naive_time_as_pacific(test_client):
+    """Naive hardware timestamps should be interpreted as Pacific local time."""
+    response = test_client.post(
+        "/api/hardware",
+        json={"name": "PacificBox", "status": "Yellow", "time": "2026-05-28 10:00:00"},
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    assert data["box"]["last_seen_local"] == "2026-05-28 10:00:00 PDT"
+
+
 def test_hardware_list_requires_login(test_client):
     """Verify the hardware list page is protected and requires login."""
     response = test_client.get("/hardware_list")


### PR DESCRIPTION
Support ISO8601 strings that end with 'Z' and normalize them before parsing. When timestamps are parsed without a timezone (naive datetimes), interpret them as Pacific local time (PACIFIC_TZ) — hardware clients often send local clock times without an offset — then convert to UTC for storage. Also added a test to verify naive hardware timestamps are treated as Pacific and recorded/displayed accordingly.