### PR TITLE
Order archived tickets by id asc

### DIFF
--- a/app/archive_utils.py
+++ b/app/archive_utils.py
@@ -124,7 +124,7 @@ def archive_ticket_query(
                 ),
             )
         )
-        .order_by(func.coalesce(Ticket.closed_at, Ticket.created_at).desc())
+        .order_by(Ticket.id.asc())
     )
 
 
@@ -277,7 +277,7 @@ def append_weekly_archive(
     tickets = (
         archive_ticket_query(start_utc, end_utc, include_end=False)
         .order_by(None)
-        .order_by(Ticket.id.desc())
+        .order_by(Ticket.id.asc())
         .yield_per(1000)
     )
 

--- a/app/archive_utils.py
+++ b/app/archive_utils.py
@@ -11,7 +11,7 @@ from typing import Iterable, Optional
 
 import click
 from flask import Flask
-from sqlalchemy import and_, func, or_
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.elements import ColumnElement
 

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -107,12 +107,12 @@ def test_archive_weekly_cli_appends_previous_week_once(test_app):
             rows = list(csv.DictReader(archive_file))
 
         assert len(rows) == 2
-        assert rows[0]["Student Name"] == "Older Inside Week"
-        assert rows[1]["Student Name"] == "Newer Inside Week"
-        assert int(rows[0]["Ticket ID"]) > int(rows[1]["Ticket ID"])
+        assert rows[0]["Student Name"] == "Newer Inside Week"
+        assert rows[1]["Student Name"] == "Older Inside Week"
+        assert int(rows[0]["Ticket ID"]) < int(rows[1]["Ticket ID"])
         assert rows[0]["Status"] == "helped"
-        assert rows[0]["Created At"] == "2026-04-20 09:00:00"
-        assert rows[0]["Closed At"] == "2026-04-20 11:00:00"
+        assert rows[0]["Created At"] == "2026-04-20 10:00:00"
+        assert rows[0]["Closed At"] == "2026-04-20 12:00:00"
         assert rows[0]["Assistant Name"] == "'=Weekly Helper"
 
         second_run = runner.invoke(


### PR DESCRIPTION
Change archive ordering to use Ticket.id ascending in archive_ticket_query and append_weekly_archive (replacing previous coalesce(...).desc and id.desc ordering). Update tests to reflect the new row ordering and adjusted timestamps/IDs in the weekly archive CSV expectations.